### PR TITLE
Added Miscellaneous FRU identify rollup

### DIFF
--- a/configs/ibm,everest/led-group-config.json
+++ b/configs/ibm,everest/led-group-config.json
@@ -9725,6 +9725,32 @@
                "Priority" : "Blink"
             }
          ]
+      },
+      {
+         "group" : "misc_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            }
+         ]
       }
    ]
 }

--- a/configs/ibm,rainier-1s4u/led-group-config.json
+++ b/configs/ibm,rainier-1s4u/led-group-config.json
@@ -309,7 +309,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -342,7 +342,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -375,7 +375,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -408,7 +408,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1570,7 +1570,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1610,7 +1610,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1650,7 +1650,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1690,7 +1690,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1730,7 +1730,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1770,7 +1770,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1810,7 +1810,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -1850,7 +1850,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -2213,7 +2213,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -2246,7 +2246,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -2434,7 +2434,7 @@
          ]
       },
       {
-         "group" : "pca955x_nvme0_identify",
+         "group" : "nvme0_identify",
          "members" : [
             {
                "Name" : "pca955x_nvme0",
@@ -3028,7 +3028,7 @@
          ]
       },
       {
-         "group" : "pca955x_nvme9_identify",
+         "group" : "nvme9_identify",
          "members" : [
             {
                "Name" : "pca955x_nvme9",
@@ -3433,6 +3433,32 @@
                "Period" : 1000,
                "Priority" : "Blink"
             },
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            }
+         ]
+      },
+      {
+         "group" : "misc_identify",
+         "members" : [
             {
                "Name" : "pca955x_front_sys_id0",
                "Action" : "On",

--- a/configs/ibm,rainier-2u/led-group-config.json
+++ b/configs/ibm,rainier-2u/led-group-config.json
@@ -4144,7 +4144,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4184,7 +4184,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4224,7 +4224,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4264,7 +4264,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4627,7 +4627,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4660,7 +4660,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -5914,7 +5914,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -6441,6 +6441,32 @@
                "Period" : 1000,
                "Priority" : "Blink"
             },
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            }
+         ]
+      },
+      {
+         "group" : "misc_identify",
+         "members" : [
             {
                "Name" : "pca955x_front_sys_id0",
                "Action" : "On",

--- a/configs/ibm,rainier-4u/led-group-config.json
+++ b/configs/ibm,rainier-4u/led-group-config.json
@@ -3437,7 +3437,7 @@
          "group" : "pcieslot9_identify",
          "members" : [
             {
-               "Name" : "pcieslot9",
+               "Name" : "pca955x_pcieslot9",
                "Action" : "Blink",
                "DutyOn" : 50,
                "Period" : 1000,
@@ -4144,7 +4144,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4184,7 +4184,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4224,7 +4224,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4264,7 +4264,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4304,7 +4304,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4344,7 +4344,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4384,7 +4384,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4424,7 +4424,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4787,7 +4787,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_enc_fault1",
+               "Name" : "pca955x_front_enc_fault1",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -4820,7 +4820,7 @@
                "Priority" : "Blink"
             },
             {
-               "Name" : "front_sys_id0",
+               "Name" : "pca955x_front_sys_id0",
                "Action" : "On",
                "DutyOn" : 50,
                "Period" : 0,
@@ -5107,7 +5107,7 @@
          ]
       },
       {
-         "group" : "pca955x_nvme1_fault",
+         "group" : "nvme1_fault",
          "members" : [
             {
                "Name" : "pca955x_nvme1",
@@ -5140,7 +5140,7 @@
          ]
       },
       {
-         "group" : "pca955x_nvme1_identify",
+         "group" : "nvme1_identify",
          "members" : [
             {
                "Name" : "pca955x_nvme1",
@@ -6601,6 +6601,32 @@
                "Period" : 1000,
                "Priority" : "Blink"
             },
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            }
+         ]
+      },
+      {
+         "group" : "misc_identify",
+         "members" : [
             {
                "Name" : "pca955x_front_sys_id0",
                "Action" : "On",


### PR DESCRIPTION
  Add enclosure identify rollup for Loction codes which do
    not have physical LED.
  Also corrected certain name errors in the json file.

Signed-off-by: Jinu Joy Thomas <jinu.joy.thomas@in.ibm.com>