### PR TITLE
Lamp test issues resolved

### DIFF
--- a/group.cpp
+++ b/group.cpp
@@ -16,20 +16,23 @@ namespace led
 /** @brief Overloaded Property Setter function */
 bool Group::asserted(bool value)
 {
+    if (customCallBack != nullptr)
+    {
+        // Call the custom callback method
+        if (customCallBack(this, value))
+        {
+            return sdbusplus::xyz::openbmc_project::Led::server::Group::
+                asserted(value);
+        }
+
+        return sdbusplus::xyz::openbmc_project::Led::server::Group::asserted();
+    }
+
     // If the value is already what is before, return right away
     if (value ==
         sdbusplus::xyz::openbmc_project::Led::server::Group::asserted())
     {
         return value;
-    }
-
-    if (customCallBack != nullptr)
-    {
-        // Call the custom callback method
-        customCallBack(this, value);
-
-        return sdbusplus::xyz::openbmc_project::Led::server::Group::asserted(
-            value);
     }
 
     // Introducing these to enable gtest.

--- a/group.hpp
+++ b/group.hpp
@@ -43,7 +43,7 @@ class Group : public GroupInherit
      */
     Group(sdbusplus::bus::bus& bus, const std::string& objPath,
           Manager& manager, Serialize& serialize,
-          std::function<void(Group*, bool)> callBack = nullptr) :
+          std::function<bool(Group*, bool)> callBack = nullptr) :
 
         GroupInherit(bus, objPath.c_str(), GroupInherit::action::defer_emit),
         path(objPath), manager(manager), serialize(serialize),
@@ -77,8 +77,14 @@ class Group : public GroupInherit
     Serialize& serialize;
 
     /** @brief Custom callback when LED group is asserted
+     * Callback that holds LED group method which handles lamp test request.
+     *
+     * @param[in] Group object - Pointer to Group object
+     * @param[in] bool - Input value (true/false)
+     *
+     * @return bool which tells if execution succeeds(true) or fails(false).
      */
-    std::function<void(Group*, bool)> customCallBack;
+    std::function<bool(Group*, bool)> customCallBack;
 };
 
 } // namespace led

--- a/lamptest.hpp
+++ b/lamptest.hpp
@@ -48,12 +48,18 @@ class LampTest
 
     /** @brief the lamp test request handler
      *
+     * If lamp test is running (Asserted=true) and if user requests to stop lamp
+     * test (Asserted input=false), Stop operation will not take place and set
+     * the Asserted to true itself. LampTest Asserted is/can be set to false
+     * only when the lamptest timer expires.
+     *
      *  @param[in]  group    -  Pointer to Group object
      *  @param[in]  value    -  true: start lamptest
      *                          false: stop lamptest
-     *  @return
+     *
+     *  @return Whether lamp test request is handled successfully or not.
      */
-    void requestHandler(Group* group, bool value);
+    bool requestHandler(Group* group, bool value);
 
     /** @brief Update physical LEDs states during lamp test and the lamp test is
      *         running


### PR DESCRIPTION
This patch solves two issues in lamp test

1. Reset lamp test timer on assert to assert case
2. Reject stopping lamp test when there is a request to
deassert lamp test.

Tested by adding print statements. Needs testing from lab.
Tested from GUI as well. Code works as expected.

================================
Test case 1:
Start lamp test . Curr state = false; Set it to true.
Result: 4mins of lamp test execution + Asserted should be back to false after 4mins

OUTPUT:
Aug 01 14:12:25 p10bmc phosphor-ledmanager[506]: Lamptest starts
Aug 01 14:12:25 p10bmc pldmd[1633]: Lamp Test: The state set PDR can not be found, entityType = 32787
Aug 01 14:12:25 p10bmc phosphor-ledmanager[506]: Failed to set Asserted property, ERROR = sd_bus_call noreply: org.freedesktop.DBus.Error.InvalidArgs: Invalid argument, PATH = /xyz/openbmc_project/led/groups/host_lamp_test

Aug 01 14:16:24 p10bmc systemd[1]: systemd-hostnamed.service: Deactivated successfully.
Aug 01 14:16:25 p10bmc phosphor-ledmanager[506]: Reached time out.
Aug 01 14:16:25 p10bmc phosphor-ledmanager[506]: Set asserted to false.
Aug 01 14:16:25 p10bmc phosphor-ledmanager[506]: call Stop API
Aug 01 14:16:25 p10bmc phosphor-ledmanager[506]: Stopping lamp test
Aug 01 14:16:34 p10bmc systemd[1]: Starting Hostname Service...

Asserted is back to false.
busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/lamp_test xyz.openbmc_project.Led.Group Asserted
b false

================================
Test case 2:
Stop lamp test(not during lamptest) . Curr state = false; Set it to false
Result: Operation not allowed + Asserted should stay false

OUTPUT:
Achieves the expected result

================================
Test case 3:
Stop lamp test(during lamptest) . Curr state = true; Set it to false
Result: Operation not allowed + Lamp test continues to execute +  Asserted should stay true until the lamp test ends

OUTPUT:

Aug 02 05:28:32 p10bmc phosphor-ledmanager[508]: Lamptest starts
Aug 02 05:28:32 p10bmc pldmd[1619]: Lamp Test: The state set PDR can not be found, entityType = 32787
Aug 02 05:28:32 p10bmc phosphor-ledmanager[508]: Failed to set Asserted property, ERROR = sd_bus_call noreply: org.freedesktop.DBus.Error.InvalidArgs: Invalid argument, PATH = /xyz/openbmc_project/led/groups/host_lamp_test
Aug 02 05:28:53 p10bmc phosphor-ledmanager[508]: Lamp test is till running. Cannot force stop the lamp test. Asserted is set back to true

Aug 02 05:29:23 p10bmc phosphor-ledmanager[508]: Lamp test is till running. Cannot force stop the lamp test. Asserted is set back to true

Aug 02 05:32:32 p10bmc phosphor-ledmanager[508]: Reached time out.
Aug 02 05:32:32 p10bmc phosphor-ledmanager[508]: call Stop API
Aug 02 05:32:32 p10bmc phosphor-ledmanager[508]: Stopping lamp test
Aug 02 05:32:33 p10bmc phosphor-ledmanager[508]: Set asserted to false.

=================================
Test case 4:
Retrigger lamp test . Curr state = true; Set it to true.
Result: 4mins Timer restarts + Asserted should be back to false after 4mins

OUTPUT:

Aug 02 05:38:08 p10bmc phosphor-ledmanager[508]: Lamptest starts
Aug 02 05:38:08 p10bmc pldmd[1619]: Lamp Test: The state set PDR can not be found, entityType = 32787
Aug 02 05:38:08 p10bmc phosphor-ledmanager[508]: Failed to set Asserted property, ERROR = sd_bus_call noreply: org.freedesktop.DBus.Error.InvalidArgs: Invalid argument, PATH = /xyz/openbmc_project/led/groups/host_lamp_test

Aug 02 05:38:13 p10bmc phosphor-ledmanager[508]: Lamptest starts
Aug 02 05:38:19 p10bmc systemd[1]: systemd-hostnamed.service: Deactivated successfully.
Aug 02 05:42:13 p10bmc phosphor-ledmanager[508]: Reached time out.
Aug 02 05:42:13 p10bmc phosphor-ledmanager[508]: call Stop API
Aug 02 05:42:13 p10bmc phosphor-ledmanager[508]: Stopping lamp test
Aug 02 05:42:13 p10bmc phosphor-ledmanager[508]: Set asserted to false

===============================

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>