### PR TITLE
Remove critical associations for a repaired CEC FRU.

### DIFF
--- a/fault-monitor/operational-status-monitor.cpp
+++ b/fault-monitor/operational-status-monitor.cpp
@@ -19,6 +19,50 @@ namespace status
 {
 namespace monitor
 {
+void Monitor::removeCriticalAssociation(const std::string& objectPath)
+{
+    try
+    {
+        PropertyValue getAssociationValue = dBusHandler.getProperty(
+            objectPath.c_str(), "xyz.openbmc_project.Association.Definitions",
+            "Associations");
+
+        auto association = std::get<AssociationsProperty>(getAssociationValue);
+
+        AssociationTuple criticalAssociation{
+            "health_rollup", "critical",
+            "/xyz/openbmc_project/inventory/system/chassis"};
+
+        auto it = std::find(association.begin(), association.end(),
+                            criticalAssociation);
+
+        if (it != association.end())
+        {
+            association.erase(it);
+
+            dBusHandler.setProperty(
+                objectPath.c_str(),
+                "xyz.openbmc_project.Association.Definitions", "Associations",
+                association);
+
+            lg2::info(
+                "Removed chassis critical association. INVENTORY_PATH = {PATH}",
+                "PATH", objectPath);
+        }
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        lg2::error(
+            "Failed to remove chassis critical association, ERROR = {ERROR}, PATH = {PATH}",
+            "ERROR", e, "PATH", objectPath);
+    }
+    catch (const std::bad_variant_access& e)
+    {
+        lg2::error(
+            "Failed to remove chassis critical association, ERROR = {ERROR}, PATH = {PATH}",
+            "ERROR", e, "PATH", objectPath);
+    }
+}
 
 void Monitor::matchHandler(sdbusplus::message::message& msg)
 {
@@ -42,6 +86,11 @@ void Monitor::matchHandler(sdbusplus::message::message& msg)
                 "Faild to get the Functional property, INVENTORY_PATH = {PATH}",
                 "PATH", invObjectPath);
             return;
+        }
+
+        if (*value)
+        {
+            removeCriticalAssociation(invObjectPath);
         }
 
         // See if the Inventory D-Bus object has an association with LED groups

--- a/fault-monitor/operational-status-monitor.hpp
+++ b/fault-monitor/operational-status-monitor.hpp
@@ -91,6 +91,16 @@ class Monitor
      */
     void updateAssertedProperty(const std::vector<std::string>& ledGroupPaths,
                                 bool value);
+
+    /**
+     * @brief API to remove chassis critical association on the d-bus object
+     *
+     * This method removes the chassis association when the operational status
+     * of the given FRU is set to true.
+     *
+     * @param[in] objectPath - The FRU's d-bus object path.
+     */
+    void removeCriticalAssociation(const std::string& objectPath);
 };
 } // namespace monitor
 } // namespace status

--- a/utils.hpp
+++ b/utils.hpp
@@ -14,11 +14,16 @@ constexpr auto MAPPER_OBJ_PATH = "/xyz/openbmc_project/object_mapper";
 constexpr auto MAPPER_IFACE = "xyz.openbmc_project.ObjectMapper";
 constexpr auto DBUS_PROPERTY_IFACE = "org.freedesktop.DBus.Properties";
 
+using AssociationTuple = std::tuple<std::string, std::string, std::string>;
+using AssociationsProperty = std::vector<AssociationTuple>;
+
 // The value of the property(type: variant, contains some basic types)
 // Eg: uint8_t : dutyOn, uint16_t : Period, std::string : Name,
-// std::vector<std::string> : endpoints, bool : Functional
-using PropertyValue = std::variant<uint8_t, uint16_t, std::string,
-                                   std::vector<std::string>, bool>;
+// std::vector<std::string> : endpoints, bool : Functional, AssociationsProperty
+// : Associations
+using PropertyValue =
+    std::variant<uint8_t, uint16_t, std::string, std::vector<std::string>, bool,
+                 AssociationsProperty>;
 
 // The name of the property
 using DbusProperty = std::string;


### PR DESCRIPTION
When a faulty CEC FRU is repaired or replaced during runtime, its corresponding chassis critical associations were left unremoved. This leads in displaying Chassis Health Rollup as "Critical" in GUI even after the fault FRU is repaired/replaced.

This commit has changes that removes the critical association on chassis, when the FRU's "Functional" property (present under the d-bus interface "xyz.openbmc_project.State.Decorator.OperationalStatus") is changed from false to true, which indicates that the FRU is repaired and is functional.

This is needed to handle hotpluggable or concurrently maintainable FRUs which are associated with the chassis.

Test:

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 xyz.openbmc_project.Association.Definitions Associations a(sss) 2 "fault_led_group" "fault_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_fault" "identify_led_group" "identify_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_identify"

// Create a chassis critical association
busctl call xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 org.freedesktop.DBus.Properties Set ssv xyz.openbmc_project.Association.Definitions Associations "a(sss)" 3 "fault_led_group" "fault_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_fault" "identify_led_group" "identify_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_identify" "health_rollup" "critical" "/xyz/openbmc_project/inventory/system/chassis"

// Query the chassis information from GUI
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Chassis/chassis "SerialNumber": "YF32UF18D00A",
  "SparePartNumber": "02WG655",
  "Status": {
    "Health": "OK",
    "HealthRollup": "Critical",     <= <= <=
    "State": "StandbyOffline"
  },

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 xyz.openbmc_project.Association.Definitions Associations a(sss) 3 "fault_led_group" "fault_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_fault" "identify_led_group" "identify_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_identify" "health_rollup" "critical" "/xyz/openbmc_project/inventory/system/chassis"

busctl get-property  xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 xyz.openbmc_project.State.Decorator.OperationalStatus Functional b false

// Set Functional property from false to true
busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 xyz.openbmc_project.State.Decorator.OperationalStatus Functional b true

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 xyz.openbmc_project.Association.Definitions Associations a(sss) 2 "fault_led_group" "fault_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_fault" "identify_led_group" "identify_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_identify"

Journal log: phosphor-fru-fault-monitor[634]: Removed chassis critical association. INVENTORY_PATH = /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0

curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Chassis/chassis
 "SerialNumber": "YF32UF18D00A",
  "SparePartNumber": "02WG655",
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK",          <= <= <=
    "State": "StandbyOffline"
  },
  "ThermalSubsystem": {
    "@odata.id": "/redfish/v1/Chassis/chassis/ThermalSubsystem"
  }

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>