### PR TITLE
BMC:LED:Removed the unused LED groups from LED config JSON file for Rainier 4U system

### DIFF
--- a/configs/ibm,rainier-4u/led-group-config.json
+++ b/configs/ibm,rainier-4u/led-group-config.json
@@ -6291,32 +6291,6 @@
          ]
       },
       {
-         "group" : "connector10_identify",
-         "members" : [
-            {
-               "Name" : "pca955x_front_sys_id0",
-               "Action" : "On",
-               "DutyOn" : 50,
-               "Period" : 0,
-               "Priority" : "Blink"
-            },
-            {
-               "Name" : "rear_enc_id0",
-               "Action" : "On",
-               "DutyOn" : 50,
-               "Period" : 0,
-               "Priority" : "Blink"
-            },
-            {
-               "Name" : "virtual_enc_id",
-               "Action" : "On",
-               "DutyOn" : 50,
-               "Period" : 0,
-               "Priority" : "Blink"
-            }
-         ]
-      },
-      {
          "group" : "connector11_identify",
          "members" : [
             {
@@ -6422,32 +6396,6 @@
       },
       {
          "group" : "connector15_identify",
-         "members" : [
-            {
-               "Name" : "pca955x_front_sys_id0",
-               "Action" : "On",
-               "DutyOn" : 50,
-               "Period" : 0,
-               "Priority" : "Blink"
-            },
-            {
-               "Name" : "rear_enc_id0",
-               "Action" : "On",
-               "DutyOn" : 50,
-               "Period" : 0,
-               "Priority" : "Blink"
-            },
-            {
-               "Name" : "virtual_enc_id",
-               "Action" : "On",
-               "DutyOn" : 50,
-               "Period" : 0,
-               "Priority" : "Blink"
-            }
-         ]
-      },
-      {
-         "group" : "connector16_identify",
          "members" : [
             {
                "Name" : "pca955x_front_sys_id0",


### PR DESCRIPTION
Removed the unused group 'connector10_identify' for Rainier 4U system. Removed the unused group 'connector16_identify' for Rainier 4U system.

Signed-off-by: Kantesh Nagaradder <kantesh.nagaradder@ibm.com>