### PR TITLE
Reset lamps after reboot

### DIFF
--- a/lamptest.cpp
+++ b/lamptest.cpp
@@ -80,6 +80,14 @@ void LampTest::stop()
         manager.drivePhysicalLED(path, Layout::Action::Off, 0, 0);
     }
 
+    if (std::filesystem::exists(LAMP_TEST_INDICATOR_FILE))
+    {
+        if (!std::filesystem::remove(LAMP_TEST_INDICATOR_FILE))
+        {
+            lg2::error("error removing file after lamp test is over");
+        }
+    }
+
     isLampTestRunning = false;
     restorePhysicalLedStates();
 }
@@ -183,6 +191,12 @@ void LampTest::start()
 
     // Notify PHYP to start the lamp test
     doHostLampTest(true);
+
+    // Create a file to maintain the state across reboots that Lamp test is on.
+    // This is required as there was a scenario where it has been found that
+    // LEDs remains in "on" state if lamp test is triggered and reboot takes
+    // place.
+    std::ofstream(LAMP_TEST_INDICATOR_FILE);
 
     // Set all the Physical action to On for lamp test
     for (const auto& path : physicalLEDPaths)

--- a/led-main.cpp
+++ b/led-main.cpp
@@ -36,6 +36,28 @@ int main(void)
     /** @brief sd_bus object manager */
     sdbusplus::server::manager::manager objManager(bus, OBJPATH);
 
+#ifdef USE_LAMP_TEST
+    if (std::filesystem::exists(LAMP_TEST_INDICATOR_FILE))
+    {
+        // we need to off all the LEDs.
+        phosphor::led::utils::DBusHandler dBusHandler;
+        std::vector<std::string> pysicalLedPaths = dBusHandler.getSubTreePaths(
+            phosphor::led::PHY_LED_PATH, phosphor::led::PHY_LED_IFACE);
+
+        for (const auto& path : pysicalLedPaths)
+        {
+            manager.drivePhysicalLED(path, phosphor::led::Layout::Action::Off,
+                                     0, 0);
+        }
+
+        // Also remove the lamp test on indicator file.
+        if (!std::filesystem::remove(LAMP_TEST_INDICATOR_FILE))
+        {
+            lg2::error("error removing file after lamp test is over");
+        }
+    }
+#endif
+
     /** @brief vector of led groups */
     std::vector<std::unique_ptr<phosphor::led::Group>> groups;
 

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ conf_data.set_quoted('CALLOUT_FWD_ASSOCIATION', 'callout')
 conf_data.set_quoted('CALLOUT_REV_ASSOCIATION', 'fault')
 conf_data.set_quoted('ELOG_ENTRY', 'entry')
 conf_data.set_quoted('LED_FAULT', 'fault')
+conf_data.set_quoted('LAMP_TEST_INDICATOR_FILE', '/var/lib/phosphor-led-manager/lampTestOn')
 
 conf_data.set('CLASS_VERSION', 1)
 conf_data.set('LED_USE_JSON', get_option('use-json').enabled())


### PR DESCRIPTION
In case lamp test has been trigerred and reboot takes place, even after reboot the lamps are found to be in the on state.

The commit switches off the lamps in case such situation is found and restores the LEDs to the state in which they were before lamp test was trigerred.

The change was done against "PE00DKX2".