### PR TITLE
sdbusplus: object: don't use 'bool' argument constructor

### DIFF
--- a/group.hpp
+++ b/group.hpp
@@ -14,12 +14,16 @@ namespace phosphor
 namespace led
 {
 
+namespace
+{
+using GroupInherit = sdbusplus::server::object_t<
+    sdbusplus::xyz::openbmc_project::Led::server::Group>;
+}
+
 /** @class Group
  *  @brief Manages group of LEDs and applies action on the elements of group
  */
-class Group :
-    sdbusplus::server::object::object<
-        sdbusplus::xyz::openbmc_project::Led::server::Group>
+class Group : public GroupInherit
 {
   public:
     Group() = delete;
@@ -41,9 +45,7 @@ class Group :
           Manager& manager, Serialize& serialize,
           std::function<void(Group*, bool)> callBack = nullptr) :
 
-        sdbusplus::server::object::object<
-            sdbusplus::xyz::openbmc_project::Led::server::Group>(
-            bus, objPath.c_str(), true),
+        GroupInherit(bus, objPath.c_str(), GroupInherit::action::defer_emit),
         path(objPath), manager(manager), serialize(serialize),
         customCallBack(callBack)
     {


### PR DESCRIPTION
`sdbusplus::server::object_t` has long had an enum-based parameter for signal action, but maintained a backwards compatible boolean mapping. It is time to remove this boolean to make it more observable which actions are being used in applications.  Map all `true` occurrences to `action::defer_emit`.

Change-Id: I5fc79b0851bd5901b5b6c8dd24a291825163dbad