### PR TITLE
Lamp test: Handle false trace getting printed

### DIFF
--- a/lamptest.cpp
+++ b/lamptest.cpp
@@ -248,10 +248,14 @@ bool LampTest::requestHandler(Group* group, bool value)
             stop();
             return true;
         }
-        else
+        else if (timer.isEnabled())
         {
             lg2::info(
                 "Lamp test is still running. Cannot force stop the lamp test. Asserted is set back to true.");
+            return false;
+        }
+        else
+        {
             return false;
         }
     }

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'phosphor-ledmanager', 'cpp',
     version : '1.0.0',
-    meson_version: '>=0.57.0',
+    meson_version: '>=0.58.0',
     default_options: [
         'warning_level=3',
         'werror=true',


### PR DESCRIPTION
When there is a request to stop lamp test, the below trace

 "Lamp test is still running. Cannot force stop the lamp test.
  Asserted is set back to true."

is getting printed even if the lamp test is not actually started.

This commit handles printing the above mentioned trace only when the lamp test timer got started and not expired.

Test:
busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/lamp_test xyz.openbmc_project.Led.Group Asserted b false

In journal no traces are seen with respect to lamp test.