### PR TITLE
LED:Invalid association for fault LED group

### DIFF
--- a/fault-monitor/operational-status-monitor.cpp
+++ b/fault-monitor/operational-status-monitor.cpp
@@ -113,8 +113,8 @@ void Monitor::matchHandler(sdbusplus::message::message& msg)
 const std::vector<std::string>
     Monitor::getLedGroupPaths(const std::string& inventoryPath) const
 {
-    // Get endpoints from the rType
-    std::string faultLedAssociation = inventoryPath + "/fault_led_group";
+    // Get endpoints from fType
+    std::string faultLedAssociation = inventoryPath + "/fault_identifying";
 
     // endpoint contains the vector of strings, where each string is a Inventory
     // D-Bus object that this, associated with this LED Group D-Bus object


### PR DESCRIPTION
The LED fault association group name has been changed from fault_led_group to fault_identifying. The code points to the invalid group name. This commit has the fix for it.

Test:

busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm1 xyz.openbmc_project.State.Decorator.OperationalStatus Functional b false

busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/ebmc_card_bmc xyz.openbmc_project.State.Decorator.OperationalStatus Functional b true

Before the fix: Error traces are found when we try to set Functional property.
phosphor-fru-fault-monitor[1180]: Failed to get endpoints property, ERROR = sd_bus_call: xyz.openbmc_project.Common.Error.ResourceNotFound: The resource is not found., PATH = /xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm1/fault_led_group
May 31 02:17:32 rain127bmc phosphor-fru-fault-monitor[1180]: The inventory D-Bus object is not associated with the LED group D-Bus object. INVENTORY_PATH = /xyz/openbmc_project/inventory/system/chassis/motherboard/vdd_vrm1

After the fix:
No error traces are found and Functional property has been updated.