### PR TITLE
led-manager: add CLI11 option and config loading

### DIFF
--- a/manager/json-config.hpp
+++ b/manager/json-config.hpp
@@ -267,5 +267,32 @@ class JsonConfig
     /** DBusHandler class handles the D-Bus operations */
     utils::DBusHandler dBusHandler;
 };
+
+/** Blocking call to find the JSON Config from DBus. */
+auto getJsonConfig()
+{
+    // Get a new Dbus
+    auto bus = sdbusplus::bus::new_bus();
+
+    // Get a new event loop
+    auto event = sdeventplus::Event::get_new();
+
+    // Attach the bus to sd_event to service user requests
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_IMPORTANT);
+    phosphor::led::JsonConfig jsonConfig(bus, event);
+
+    // The event loop will be terminated from inside of a function in JsonConfig
+    // after finding the configuration file
+    if (jsonConfig.getConfFile().empty())
+    {
+        event.loop();
+    }
+
+    // Detach the bus from its sd_event event loop object
+    bus.detach_event();
+
+    return jsonConfig.getConfFile();
+}
+
 } // namespace led
 } // namespace phosphor

--- a/manager/json-parser.hpp
+++ b/manager/json-parser.hpp
@@ -149,29 +149,18 @@ const LedMap loadJsonConfig(const fs::path& path)
 
 /** @brief Get led map from LED groups JSON config
  *
+ *  @param[in] config - Path to the JSON config.
  *  @return LedMap - Generated an std::map of LedAction
+ *
+ *  @note if config is an empty string, daemon will interrogate dbus for
+ *        compatible strings.
  */
-const LedMap getSystemLedMap()
+const LedMap getSystemLedMap(fs::path config)
 {
-    // Get a new Dbus
-    auto bus = sdbusplus::bus::new_bus();
-
-    // Get a new event loop
-    auto event = sdeventplus::Event::get_new();
-
-    // Attach the bus to sd_event to service user requests
-    bus.attach_event(event.get(), SD_EVENT_PRIORITY_IMPORTANT);
-    phosphor::led::JsonConfig jsonConfig(bus, event);
-
-    // The event loop will be terminated from inside of a function in JsonConfig
-    // after finding the configuration file
-    if (jsonConfig.getConfFile().empty())
+    if (config.empty())
     {
-        event.loop();
+        config = phosphor::led::getJsonConfig();
     }
 
-    // Detach the bus from its sd_event event loop object
-    bus.detach_event();
-
-    return loadJsonConfig(jsonConfig.getConfFile());
+    return loadJsonConfig(config);
 }

--- a/manager/led-main.cpp
+++ b/manager/led-main.cpp
@@ -14,12 +14,22 @@
 #include "lamptest.hpp"
 #endif
 
+#include <CLI/CLI.hpp>
 #include <sdeventplus/event.hpp>
 
 #include <iostream>
 
-int main(void)
+int main(int argc, char** argv)
 {
+    CLI::App app("phosphor-led-manager");
+
+#ifdef LED_USE_JSON
+    std::string configFile{};
+    app.add_option("-c,--config", configFile, "Path to JSON config");
+#endif
+
+    CLI11_PARSE(app, argc, argv);
+
     // Get a default event loop
     auto event = sdeventplus::Event::get_default();
 
@@ -27,7 +37,7 @@ int main(void)
     auto& bus = phosphor::led::utils::DBusHandler::getBus();
 
 #ifdef LED_USE_JSON
-    auto systemLedMap = getSystemLedMap();
+    auto systemLedMap = getSystemLedMap(configFile);
 #endif
 
     /** @brief Group manager object */

--- a/meson.build
+++ b/meson.build
@@ -113,6 +113,15 @@ foreach g : generated_sources generated_others
     endforeach
 endforeach
 
+if cpp.has_header('CLI/CLI.hpp')
+    CLI11_dep = declare_dependency()
+else
+    CLI11_dep = dependency(
+        'CLI11',
+        fallback: [ 'CLI11', 'CLI11_dep' ],
+    )
+endif
+
 deps = [
     sdbusplus_dep,
     sdeventplus_dep,

--- a/subprojects/CLI11.wrap
+++ b/subprojects/CLI11.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/CLIUtils/CLI11.git
+revision = HEAD


### PR DESCRIPTION
To facilitate localized testing of JSON config loading, add an option that allows the configuration to be directly passed, rather than try to determine it from entity-manager config off dbus.


Change-Id: I80d7051bf312044c68f44bcdb9ac02364f9abac3