### PR TITLE
1050:manager: add timer for failed LED actions

### DIFF
--- a/led-main.cpp
+++ b/led-main.cpp
@@ -31,7 +31,7 @@ int main(void)
 #endif
 
     /** @brief Group manager object */
-    phosphor::led::Manager manager(bus, systemLedMap);
+    phosphor::led::Manager manager(bus, systemLedMap, event);
 
     /** @brief sd_bus object manager */
     sdbusplus::server::manager::manager objManager(bus, OBJPATH);

--- a/manager.cpp
+++ b/manager.cpp
@@ -7,6 +7,7 @@
 #include <xyz/openbmc_project/Led/Physical/server.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <string>
 namespace phosphor
@@ -117,34 +118,67 @@ void Manager::driveLEDs(group& ledsAssert, group& ledsDeAssert)
         return;
     }
 #endif
-    // This order of LED operation is important.
-    if (ledsDeAssert.size())
+    group newReqChangedLeds;
+    std::vector<std::pair<group&, group&>> actionsVec = {
+        {reqLedsAssert, ledsAssert}, {reqLedsDeAssert, ledsDeAssert}};
+
+    timer.setEnabled(false);
+    std::set_union(ledsAssert.begin(), ledsAssert.end(), ledsDeAssert.begin(),
+                   ledsDeAssert.end(),
+                   std::inserter(newReqChangedLeds, newReqChangedLeds.begin()),
+                   ledLess);
+
+    // prepare reqLedsAssert & reqLedsDeAssert
+    for (auto pair : actionsVec)
     {
-        for (const auto& it : ledsDeAssert)
-        {
-            std::string objPath = std::string(PHY_LED_PATH) + it.name;
-            lg2::debug("De-Asserting LED, NAME = {NAME}", "NAME", it.name);
-            drivePhysicalLED(objPath, Layout::Action::Off, it.dutyOn,
-                             it.period);
-        }
+        group tmpSet;
+
+        // Discard current required LED actions, if these LEDs have new actions
+        // in newReqChangedLeds.
+        std::set_difference(pair.first.begin(), pair.first.end(),
+                            newReqChangedLeds.begin(), newReqChangedLeds.end(),
+                            std::inserter(tmpSet, tmpSet.begin()), ledLess);
+
+        // Union the remaining LED actions with new LED actions.
+        pair.first.clear();
+        std::set_union(tmpSet.begin(), tmpSet.end(), pair.second.begin(),
+                       pair.second.end(),
+                       std::inserter(pair.first, pair.first.begin()), ledLess);
     }
 
-    if (ledsAssert.size())
-    {
-        for (const auto& it : ledsAssert)
-        {
-            std::string objPath = std::string(PHY_LED_PATH) + it.name;
-            lg2::debug("Asserting LED, NAME = {NAME}", "NAME", it.name);
-            drivePhysicalLED(objPath, it.action, it.dutyOn, it.period);
-        }
-    }
+    driveLedsHandler();
     return;
 }
 
+/**
+ * @brief Checks if sysfs present for the given PSU
+ *
+ * @param[in] phyLedPath - PSU LED object path.
+ *
+ * @return true if given psu led object is valid, false otherwise.
+ */
+static bool isSysfsPresentForPSU(const std::string& phyLedPath)
+{
+    // Extract the group name from physical led object path (object path like,
+    // /xyz/openbmc_project/led/physical/cffps1_68)
+    std::string ledGroup = std::filesystem::path(phyLedPath).filename();
+    std::replace(ledGroup.begin(), ledGroup.end(), '_', '-');
+
+    // Form the sysfs path for the given led group
+    std::filesystem::path sysfsPath(std::string("/sys/class/leds/" + ledGroup));
+
+    // Check for the sysfs existence
+    if (std::filesystem::exists(sysfsPath))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 // Calls into driving physical LED post choosing the action
-void Manager::drivePhysicalLED(const std::string& objPath,
-                               Layout::Action action, uint8_t dutyOn,
-                               const uint16_t period)
+int Manager::drivePhysicalLED(const std::string& objPath, Layout::Action action,
+                              uint8_t dutyOn, const uint16_t period)
 {
     try
     {
@@ -165,12 +199,22 @@ void Manager::drivePhysicalLED(const std::string& objPath,
     }
     catch (const std::exception& e)
     {
+        // For PSU, if the given driver is not present in sysfs path and
+        // set-property call fails, do not log error.
+        if ((objPath.find("cffps") != std::string::npos) &&
+            (!isSysfsPresentForPSU(objPath)))
+        {
+            return -1;
+        }
+
         lg2::error(
             "Error setting property for physical LED, ERROR = {ERROR}, OBJECT_PATH = {PATH}",
             "ERROR", e, "PATH", objPath);
+
+        return -1;
     }
 
-    return;
+    return 0;
 }
 
 /** @brief Returns action string based on enum */
@@ -195,5 +239,52 @@ std::string Manager::getPhysicalAction(Layout::Action action)
     }
 }
 
+void Manager::driveLedsHandler(void)
+{
+    group failedLedsAssert;
+    group failedLedsDeAssert;
+
+    // This order of LED operation is important.
+    if (reqLedsDeAssert.size())
+    {
+        for (const auto& it : reqLedsDeAssert)
+        {
+            std::string objPath = std::string(PHY_LED_PATH) + it.name;
+            lg2::debug("De-Asserting LED, NAME = {NAME}", "NAME", it.name);
+            if (drivePhysicalLED(objPath, Layout::Action::Off, it.dutyOn,
+                                 it.period))
+            {
+                failedLedsDeAssert.insert(it);
+            }
+        }
+    }
+
+    if (reqLedsAssert.size())
+    {
+        for (const auto& it : reqLedsAssert)
+        {
+            std::string objPath = std::string(PHY_LED_PATH) + it.name;
+            lg2::debug("Asserting LED, NAME = {NAME}", "NAME", it.name);
+            if (drivePhysicalLED(objPath, it.action, it.dutyOn, it.period))
+            {
+                failedLedsAssert.insert(it);
+            }
+        }
+    }
+
+    reqLedsAssert = failedLedsAssert;
+    reqLedsDeAssert = failedLedsDeAssert;
+
+    if (reqLedsDeAssert.empty() && reqLedsAssert.empty())
+    {
+        timer.setEnabled(false);
+    }
+    else
+    {
+        timer.restartOnce(std::chrono::seconds(1));
+    }
+
+    return;
+}
 } // namespace led
 } // namespace phosphor


### PR DESCRIPTION
The current manager performs LED ActionSet one-time only when LED group asserted property changes, so if the physical LED object path is not ready when it is set, the LED will be in an error state. Most of time this error occurs at BMC booting due phospohr-led-manager starts before LED driver is probed.

In order to correct LED state after physical LED is ready, add a timer to repeatedly setting failed LED after 1 second.

Test works as expected:

busctl call xyz.openbmc_project.Logging /xyz/openbmc_project/logging xyz.openbmc_project.Logging.Create Create ssa{ss}  xyz.openbmc_project.Power.PowerSupply.Error.Fault xyz.openbmc_project.Logging.Entry.Level.Error 1 CALLOUT_INVENTORY_PATH /xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0

reboot

cat /sys/class/leds/cffps2-68/brightness
255

cat /sys/class/leds/led-rear-enc-fault0/brightness
1

cat /sys/class/leds/pca955x\:front-enc-fault1/brightness
255

busctl get-property  xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/powersupply0_fault xyz.openbmc_project.Led.Group Asserted
b true

-------------------------------------------
 - Created psu fault and fan fault
Reboot - at bmc standby -> clears all fru faults and enclosure faults and check log 
Reboot at phyp standby => All fru fault leds and enclosure faults and checklog stays on
AC cycle - clears all enclosure, checklog, and fru faults

- Created psu fault and fan fault and set Asserted = false for fan = > and checked  enclosure still stays on as the PSU fault is not cleared yet.
----------------------------------------------
Change-Id: I0bb46189c79c961cdaa501a7386346c2bb351252