### PR TITLE
switch map to unordered_map

### DIFF
--- a/fault-monitor/fru-fault-monitor.cpp
+++ b/fault-monitor/fru-fault-monitor.cpp
@@ -33,15 +33,16 @@ using AssociationList =
     std::vector<std::tuple<std::string, std::string, std::string>>;
 using Attributes = std::variant<bool, AssociationList>;
 using PropertyName = std::string;
-using PropertyMap = std::map<PropertyName, Attributes>;
+using PropertyMap = std::unordered_map<PropertyName, Attributes>;
 using InterfaceName = std::string;
-using InterfaceMap = std::map<InterfaceName, PropertyMap>;
+using InterfaceMap = std::unordered_map<InterfaceName, PropertyMap>;
 
 using Service = std::string;
 using Path = std::string;
 using Interface = std::string;
 using Interfaces = std::vector<Interface>;
-using MapperResponseType = std::map<Path, std::map<Service, Interfaces>>;
+using MapperResponseType =
+    std::unordered_map<Path, std::unordered_map<Service, Interfaces>>;
 
 using MethodErr =
     sdbusplus::xyz::openbmc_project::Led::Mapper::Error::MethodError;
@@ -56,7 +57,7 @@ std::string getService(sdbusplus::bus::bus& bus, const std::string& path)
                                       MAPPER_IFACE, "GetObject");
     mapper.append(path.c_str(), std::vector<std::string>({OBJMGR_IFACE}));
 
-    std::map<std::string, std::vector<std::string>> mapperResponse;
+    std::unordered_map<std::string, std::vector<std::string>> mapperResponse;
     try
     {
         auto mapperResponseMsg = bus.call(mapper);

--- a/fault-monitor/operational-status-monitor.cpp
+++ b/fault-monitor/operational-status-monitor.cpp
@@ -73,7 +73,7 @@ void Monitor::matchHandler(sdbusplus::message::message& msg)
     // Get all the properties of
     // "xyz.openbmc_project.State.Decorator.OperationalStatus" interface
     std::string interfaceName{};
-    std::map<std::string, std::variant<bool>> properties;
+    std::unordered_map<std::string, std::variant<bool>> properties;
     msg.read(interfaceName, properties);
 
     const auto it = properties.find("Functional");

--- a/manager/json-config.hpp
+++ b/manager/json-config.hpp
@@ -100,8 +100,10 @@ class JsonConfig
     void ifacesAddedCallback(sdbusplus::message::message& msg)
     {
         sdbusplus::message::object_path path;
-        std::map<std::string,
-                 std::map<std::string, std::variant<std::vector<std::string>>>>
+        std::unordered_map<
+            std::string,
+            std::unordered_map<std::string,
+                               std::variant<std::vector<std::string>>>>
             interfaces;
 
         msg.read(path, interfaces);

--- a/manager/json-parser.hpp
+++ b/manager/json-parser.hpp
@@ -16,11 +16,12 @@ namespace fs = std::filesystem;
 
 using Json = nlohmann::json;
 using LedAction = std::set<phosphor::led::Layout::LedAction>;
-using LedMap = std::map<std::string, LedAction>;
+using LedMap = std::unordered_map<std::string, LedAction>;
 
 // Priority for a particular LED needs to stay SAME across all groups
 // phosphor::led::Layout::Action can only be one of `Blink` and `On`
-using PriorityMap = std::map<std::string, phosphor::led::Layout::Action>;
+using PriorityMap =
+    std::unordered_map<std::string, phosphor::led::Layout::Action>;
 
 /** @brief Parse LED JSON file and output Json object
  *
@@ -70,7 +71,7 @@ phosphor::led::Layout::Action getAction(const std::string& action)
  *
  *  @param[in] name - led name member of each group
  *  @param[in] priority - member priority of each group
- *  @param[out] priorityMap - std::map, key:name, value:priority
+ *  @param[out] priorityMap - std::unordered_map, key:name, value:priority
  *
  *  @return
  */
@@ -100,7 +101,7 @@ void validatePriority(const std::string& name,
 
 /** @brief Load JSON config and return led map
  *
- *  @return LedMap - Generated an std::map of LedAction
+ *  @return LedMap - Generated an std::unordered_map of LedAction
  */
 const LedMap loadJsonConfig(const fs::path& path)
 {
@@ -139,7 +140,7 @@ const LedMap loadJsonConfig(const fs::path& path)
             ledActions.emplace(ledAction);
         }
 
-        // Generated an std::map of LedGroupNames to std::set of LEDs
+        // Generated an std::unordered_map of LedGroupNames to std::set of LEDs
         // containing the name and properties.
         ledMap.emplace(objpath, ledActions);
     }
@@ -150,7 +151,7 @@ const LedMap loadJsonConfig(const fs::path& path)
 /** @brief Get led map from LED groups JSON config
  *
  *  @param[in] config - Path to the JSON config.
- *  @return LedMap - Generated an std::map of LedAction
+ *  @return LedMap - Generated an std::unordered_map of LedAction
  *
  *  @note if config is an empty string, daemon will interrogate dbus for
  *        compatible strings.

--- a/manager/ledlayout.hpp
+++ b/manager/ledlayout.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 
 namespace phosphor
 {

--- a/manager/manager.hpp
+++ b/manager/manager.hpp
@@ -3,9 +3,9 @@
 #include "ledlayout.hpp"
 #include "utils.hpp"
 
-#include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 
 namespace phosphor
 {
@@ -69,7 +69,7 @@ class Manager
     }
 
     using group = std::set<phosphor::led::Layout::LedAction>;
-    using LedLayout = std::map<std::string, group>;
+    using LedLayout = std::unordered_map<std::string, group>;
 
     /** @brief static global map constructed at compile time */
     const LedLayout& ledMap;
@@ -142,7 +142,7 @@ class Manager
     sdbusplus::bus::bus& bus;
 
     /** Map of physical LED path to service name */
-    std::map<std::string, std::string> phyLeds{};
+    std::unordered_map<std::string, std::string> phyLeds{};
 
     /** DBusHandler class handles the D-Bus operations */
     DBusHandler dBusHandler;

--- a/scripts/parse_led.py
+++ b/scripts/parse_led.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         ofile.write("/* !!! WARNING: This is a GENERATED Code..")
         ofile.write("Please do NOT Edit !!! */\n\n")
 
-        ofile.write("static const std::map<std::string,")
+        ofile.write("static const std::unordered_map<std::string,")
         ofile.write("std::set<phosphor::led::Layout::LedAction>>")
         ofile.write(" systemLedMap = {\n\n")
         for group in list(ifile.keys()):

--- a/test/led-test-map.hpp
+++ b/test/led-test-map.hpp
@@ -1,10 +1,11 @@
 #include "ledlayout.hpp"
 
-#include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     singleLedOn = {
         {"/xyz/openbmc_project/ledmanager/groups/SingleLed",
          {
@@ -13,7 +14,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     singleLedBlink = {
         {"/xyz/openbmc_project/ledmanager/groups/SingleLed",
          {
@@ -22,7 +24,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     singleLedBlinkOverrideOn = {
         {"/xyz/openbmc_project/ledmanager/groups/SingleLed",
          {
@@ -31,7 +34,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     multipleLedsOn = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLeds",
          {
@@ -44,7 +48,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     multipleLedsBlink = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLeds",
          {
@@ -57,7 +62,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     multipleLedsOnAndBlink = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsMix",
          {
@@ -74,7 +80,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     twoGroupsWithDistinctLEDsOn = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -96,7 +103,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     twoGroupsWithOneComonLEDOn = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -118,7 +126,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     twoGroupsWithOneComonLEDOnOneLEDBlinkPriority = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -140,7 +149,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     twoGroupsWithOneComonLEDOnPriority = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -162,7 +172,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     twoGroupsWithMultiplComonLEDOn = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -186,7 +197,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     twoGroupsWithMultipleComonLEDInDifferentState = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -212,7 +224,8 @@ static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
          }},
 };
 
-static const std::map<std::string, std::set<phosphor::led::Layout::LedAction>>
+static const std::unordered_map<std::string,
+                                std::set<phosphor::led::Layout::LedAction>>
     twoGroupsWithMultipleComonLEDInDifferentStateDiffPriority = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {

--- a/utils.cpp
+++ b/utils.cpp
@@ -15,7 +15,7 @@ const std::string DBusHandler::getService(const std::string& path,
 {
 
     using InterfaceList = std::vector<std::string>;
-    std::map<std::string, std::vector<std::string>> mapperResponse;
+    std::unordered_map<std::string, std::vector<std::string>> mapperResponse;
 
     auto& bus = DBusHandler::getBus();
 

--- a/utils.hpp
+++ b/utils.hpp
@@ -2,7 +2,7 @@
 #include <sdbusplus/server.hpp>
 
 #include <cstdint>
-#include <map>
+#include <unordered_map>
 #include <vector>
 namespace phosphor
 {
@@ -30,7 +30,7 @@ using PropertyValue =
 using DbusProperty = std::string;
 
 // The Map to constructs all properties values of the interface
-using PropertyMap = std::map<DbusProperty, PropertyValue>;
+using PropertyMap = std::unordered_map<DbusProperty, PropertyValue>;
 
 /**
  *  @class DBusHandler


### PR DESCRIPTION
Generally, unordered_maps should be preferred over map because they have faster access times (O(1)) and tend to allocate less dynamic memory.  We do not rely on ordered iteration in any current use of maps, so it is safe to do a full replace.


Change-Id: Ieaa28ac7f70f9913d13d25142fea9861d49bb23f