### PR TITLE
Led upstream commits

### DIFF
--- a/fault-monitor/fru-fault-monitor.cpp
+++ b/fault-monitor/fru-fault-monitor.cpp
@@ -19,13 +19,12 @@ namespace monitor
 
 using namespace phosphor::logging;
 
-constexpr auto MAPPER_BUSNAME = "xyz.openbmc_project.ObjectMapper";
-constexpr auto MAPPER_OBJ_PATH = "/xyz/openbmc_project/object_mapper";
-constexpr auto MAPPER_IFACE = "xyz.openbmc_project.ObjectMapper";
-constexpr auto OBJMGR_IFACE = "org.freedesktop.DBus.ObjectManager";
-constexpr auto LED_GROUPS = "/xyz/openbmc_project/led/groups/";
-constexpr auto LOG_PATH = "/xyz/openbmc_project/logging";
-constexpr auto LOG_IFACE = "xyz.openbmc_project.Logging.Entry";
+static constexpr auto mapperBusName = "xyz.openbmc_project.ObjectMapper";
+static constexpr auto mapperObjPath = "/xyz/openbmc_project/object_mapper";
+static constexpr auto mapperIntf = "xyz.openbmc_project.ObjectMapper";
+static constexpr auto objMgrIntf = "org.freedesktop.DBus.ObjectManager";
+static constexpr auto ledGroups = "/xyz/openbmc_project/led/groups/";
+static constexpr auto logIntf = "xyz.openbmc_project.Logging.Entry";
 
 using AssociationList =
     std::vector<std::tuple<std::string, std::string, std::string>>;
@@ -49,9 +48,9 @@ using InvalidArgumentErr =
 
 std::string getService(sdbusplus::bus_t& bus, const std::string& path)
 {
-    auto mapper = bus.new_method_call(MAPPER_BUSNAME, MAPPER_OBJ_PATH,
-                                      MAPPER_IFACE, "GetObject");
-    mapper.append(path.c_str(), std::vector<std::string>({OBJMGR_IFACE}));
+    auto mapper = bus.new_method_call(mapperBusName, mapperObjPath, mapperIntf,
+                                      "GetObject");
+    mapper.append(path.c_str(), std::vector<std::string>({objMgrIntf}));
 
     std::unordered_map<std::string, std::vector<std::string>> mapperResponse;
     try
@@ -82,7 +81,7 @@ void action(sdbusplus::bus_t& bus, const std::string& path, bool assert)
     std::string service;
     try
     {
-        std::string groups{LED_GROUPS};
+        std::string groups{ledGroups};
         groups.pop_back();
         service = getService(bus, groups);
     }
@@ -103,7 +102,7 @@ void action(sdbusplus::bus_t& bus, const std::string& path, bool assert)
     }
     auto unit = path.substr(pos + 1);
 
-    std::string ledPath = LED_GROUPS + unit + '_' + LED_FAULT;
+    std::string ledPath = ledGroups + unit + '_' + LED_FAULT;
 
     auto method = bus.new_method_call(service.c_str(), ledPath.c_str(),
                                       "org.freedesktop.DBus.Properties", "Set");
@@ -187,11 +186,11 @@ void Add::created(sdbusplus::message_t& msg)
 void getLoggingSubTree(sdbusplus::bus_t& bus, MapperResponseType& subtree)
 {
     auto depth = 0;
-    auto mapperCall = bus.new_method_call(MAPPER_BUSNAME, MAPPER_OBJ_PATH,
-                                          MAPPER_IFACE, "GetSubTree");
+    auto mapperCall = bus.new_method_call(mapperBusName, mapperObjPath,
+                                          mapperIntf, "GetSubTree");
     mapperCall.append("/");
     mapperCall.append(depth);
-    mapperCall.append(std::vector<Interface>({LOG_IFACE}));
+    mapperCall.append(std::vector<Interface>({logIntf}));
 
     try
     {

--- a/fault-monitor/fru-fault-monitor.cpp
+++ b/fault-monitor/fru-fault-monitor.cpp
@@ -156,9 +156,7 @@ void Add::created(sdbusplus::message_t& msg)
 
     // Nothing else shows when a specific error log
     // has been created. Do it here.
-    // TODO:(phosphor-logging#25): support sdbusplus::message::object_path
-    // directly.
-    lg2::info("{PATH} created", "PATH", objectPath.str);
+    lg2::info("{PATH} created", "PATH", objectPath);
 
     auto attr = iter->second.find("Associations");
     if (attr == iter->second.end())

--- a/fault-monitor/fru-fault-monitor.cpp
+++ b/fault-monitor/fru-fault-monitor.cpp
@@ -47,7 +47,7 @@ using ResourceNotFoundErr =
 using InvalidArgumentErr =
     sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
 
-std::string getService(sdbusplus::bus::bus& bus, const std::string& path)
+std::string getService(sdbusplus::bus_t& bus, const std::string& path)
 {
     auto mapper = bus.new_method_call(MAPPER_BUSNAME, MAPPER_OBJ_PATH,
                                       MAPPER_IFACE, "GetObject");
@@ -59,7 +59,7 @@ std::string getService(sdbusplus::bus::bus& bus, const std::string& path)
         auto mapperResponseMsg = bus.call(mapper);
         mapperResponseMsg.read(mapperResponse);
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         lg2::error(
             "Failed to parse getService mapper response, ERROR = {ERROR}",
@@ -77,7 +77,7 @@ std::string getService(sdbusplus::bus::bus& bus, const std::string& path)
     return mapperResponse.cbegin()->first;
 }
 
-void action(sdbusplus::bus::bus& bus, const std::string& path, bool assert)
+void action(sdbusplus::bus_t& bus, const std::string& path, bool assert)
 {
     std::string service;
     try
@@ -116,7 +116,7 @@ void action(sdbusplus::bus::bus& bus, const std::string& path, bool assert)
     {
         bus.call_noreply(method);
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         // Log an info message, system may not have all the LED Groups defined
         lg2::info("Failed to Assert LED Group, ERROR = {ERROR}", "ERROR", e);
@@ -125,7 +125,7 @@ void action(sdbusplus::bus::bus& bus, const std::string& path, bool assert)
     return;
 }
 
-void Add::created(sdbusplus::message::message& msg)
+void Add::created(sdbusplus::message_t& msg)
 {
     auto bus = msg.get_bus();
 
@@ -135,7 +135,7 @@ void Add::created(sdbusplus::message::message& msg)
     {
         msg.read(objectPath, interfaces);
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         lg2::error("Failed to parse created message, ERROR = {ERROR}", "ERROR",
                    e);
@@ -186,7 +186,7 @@ void Add::created(sdbusplus::message::message& msg)
     return;
 }
 
-void getLoggingSubTree(sdbusplus::bus::bus& bus, MapperResponseType& subtree)
+void getLoggingSubTree(sdbusplus::bus_t& bus, MapperResponseType& subtree)
 {
     auto depth = 0;
     auto mapperCall = bus.new_method_call(MAPPER_BUSNAME, MAPPER_OBJ_PATH,
@@ -200,7 +200,7 @@ void getLoggingSubTree(sdbusplus::bus::bus& bus, MapperResponseType& subtree)
         auto mapperResponseMsg = bus.call(mapperCall);
         mapperResponseMsg.read(subtree);
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         lg2::error(
             "Failed to parse existing callouts subtree message, ERROR = {ERROR}",
@@ -208,7 +208,7 @@ void getLoggingSubTree(sdbusplus::bus::bus& bus, MapperResponseType& subtree)
     }
 }
 
-void Add::processExistingCallouts(sdbusplus::bus::bus& bus)
+void Add::processExistingCallouts(sdbusplus::bus_t& bus)
 {
     MapperResponseType mapperResponse;
 
@@ -239,7 +239,7 @@ void Add::processExistingCallouts(sdbusplus::bus::bus& bus)
         {
             reply.read(assoc);
         }
-        catch (const sdbusplus::exception::exception& e)
+        catch (const sdbusplus::exception_t& e)
         {
             lg2::error(
                 "Failed to parse existing callouts associations message, ERROR = {ERROR}",
@@ -265,7 +265,7 @@ void Add::processExistingCallouts(sdbusplus::bus::bus& bus)
     }
 }
 
-void Remove::removed(sdbusplus::message::message& msg)
+void Remove::removed(sdbusplus::message_t& msg)
 {
     auto bus = msg.get_bus();
 

--- a/fault-monitor/fru-fault-monitor.hpp
+++ b/fault-monitor/fru-fault-monitor.hpp
@@ -23,7 +23,7 @@ namespace monitor
  *  @param[in] path      -  Inventory path of the FRU
  *  @param[in] assert    -  Assert if true deassert if false
  */
-void action(sdbusplus::bus::bus& bus, const std::string& path, bool assert);
+void action(sdbusplus::bus_t& bus, const std::string& path, bool assert);
 
 class Remove;
 
@@ -45,7 +45,7 @@ class Add
     /** @brief constructs Add a watch for FRU faults.
      *  @param[in] bus -  The Dbus bus object
      */
-    explicit Add(sdbusplus::bus::bus& bus) :
+    explicit Add(sdbusplus::bus_t& bus) :
         matchCreated(
             bus,
             sdbusplus::bus::match::rules::interfacesAdded() +
@@ -65,12 +65,12 @@ class Add
     /** @brief Callback function for fru fault created
      *  @param[in] msg       - Data associated with subscribed signal
      */
-    void created(sdbusplus::message::message& msg);
+    void created(sdbusplus::message_t& msg);
 
     /** @brief This function process all callouts at application start
      *  @param[in] bus - The Dbus bus object
      */
-    void processExistingCallouts(sdbusplus::bus::bus& bus);
+    void processExistingCallouts(sdbusplus::bus_t& bus);
 };
 
 /** @class Remove
@@ -92,7 +92,7 @@ class Remove
      *  @param[in] bus  -  The Dbus bus object
      *  @param[in] path -  Inventory path to fru
      */
-    Remove(sdbusplus::bus::bus& bus, const std::string& path) :
+    Remove(sdbusplus::bus_t& bus, const std::string& path) :
         inventoryPath(path),
         matchRemoved(bus, match(path),
                      std::bind(std::mem_fn(&Remove::removed), this,
@@ -111,7 +111,7 @@ class Remove
     /** @brief Callback function for fru fault created
      *  @param[in] msg       - Data associated with subscribed signal
      */
-    void removed(sdbusplus::message::message& msg);
+    void removed(sdbusplus::message_t& msg);
 
     /** @brief function to create fault remove match for a fru
      *  @param[in] path  - Inventory path of the faulty unit.

--- a/fault-monitor/fru-fault-monitor.hpp
+++ b/fault-monitor/fru-fault-monitor.hpp
@@ -45,7 +45,7 @@ class Add
     /** @brief constructs Add a watch for FRU faults.
      *  @param[in] bus -  The Dbus bus object
      */
-    Add(sdbusplus::bus::bus& bus) :
+    explicit Add(sdbusplus::bus::bus& bus) :
         matchCreated(
             bus,
             sdbusplus::bus::match::rules::interfacesAdded() +

--- a/fault-monitor/monitor-main.cpp
+++ b/fault-monitor/monitor-main.cpp
@@ -9,7 +9,7 @@
 int main(void)
 {
     /** @brief Dbus constructs used by Fault Monitor */
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
 
 #ifdef MONITOR_OPERATIONAL_STATUS
     phosphor::led::Operational::status::monitor::Monitor monitor(bus);

--- a/fault-monitor/operational-status-monitor.cpp
+++ b/fault-monitor/operational-status-monitor.cpp
@@ -136,9 +136,7 @@ const std::vector<std::string>
         return {};
     }
 
-    auto& endpoints = std::get<std::vector<std::string>>(endpoint);
-
-    return endpoints;
+    return std::get<std::vector<std::string>>(endpoint);
 }
 
 void Monitor::updateAssertedProperty(

--- a/fault-monitor/operational-status-monitor.cpp
+++ b/fault-monitor/operational-status-monitor.cpp
@@ -64,7 +64,7 @@ void Monitor::removeCriticalAssociation(const std::string& objectPath)
     }
 }
 
-void Monitor::matchHandler(sdbusplus::message::message& msg)
+void Monitor::matchHandler(sdbusplus::message_t& msg)
 {
     // Get the ObjectPath of the `xyz.openbmc_project.Inventory.Manager`
     // service
@@ -127,7 +127,7 @@ const std::vector<std::string>
                                            "xyz.openbmc_project.Association",
                                            "endpoints");
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         lg2::error(
             "Failed to get endpoints property, ERROR = {ERROR}, PATH = {PATH}",
@@ -161,7 +161,7 @@ void Monitor::updateAssertedProperty(
             dBusHandler.setProperty(path, "xyz.openbmc_project.Led.Group",
                                     "Asserted", assertedValue);
         }
-        catch (const sdbusplus::exception::exception& e)
+        catch (const sdbusplus::exception_t& e)
         {
             lg2::error(
                 "Failed to set Asserted property, ERROR = {ERROR}, PATH = {PATH}",

--- a/fault-monitor/operational-status-monitor.hpp
+++ b/fault-monitor/operational-status-monitor.hpp
@@ -39,7 +39,7 @@ class Monitor
      *
      *  @param[in] bus -  D-Bus object
      */
-    Monitor(sdbusplus::bus::bus& bus) :
+    explicit Monitor(sdbusplus::bus::bus& bus) :
         bus(bus),
         matchSignal(bus,
                     "type='signal',member='PropertiesChanged', "

--- a/fault-monitor/operational-status-monitor.hpp
+++ b/fault-monitor/operational-status-monitor.hpp
@@ -39,7 +39,7 @@ class Monitor
      *
      *  @param[in] bus -  D-Bus object
      */
-    explicit Monitor(sdbusplus::bus::bus& bus) :
+    explicit Monitor(sdbusplus::bus_t& bus) :
         bus(bus),
         matchSignal(bus,
                     "type='signal',member='PropertiesChanged', "
@@ -54,7 +54,7 @@ class Monitor
 
   private:
     /** @brief sdbusplus D-Bus connection. */
-    sdbusplus::bus::bus& bus;
+    sdbusplus::bus_t& bus;
 
     /** @brief sdbusplus signal matches for Monitor */
     sdbusplus::bus::match_t matchSignal;
@@ -70,7 +70,7 @@ class Monitor
      *
      * @param[in] msg - The D-Bus message contents
      */
-    void matchHandler(sdbusplus::message::message& msg);
+    void matchHandler(sdbusplus::message_t& msg);
 
     /**
      * @brief From the Inventory D-Bus object, obtains the associated LED group

--- a/manager/group.hpp
+++ b/manager/group.hpp
@@ -41,8 +41,8 @@ class Group : public GroupInherit
      * @param[in] serialize - Serialize object
      * @param[in] callBack  - Custom callback when LED group is asserted
      */
-    Group(sdbusplus::bus::bus& bus, const std::string& objPath,
-          Manager& manager, Serialize& serialize,
+    Group(sdbusplus::bus_t& bus, const std::string& objPath, Manager& manager,
+          Serialize& serialize,
           std::function<bool(Group*, bool)> callBack = nullptr) :
 
         GroupInherit(bus, objPath.c_str(), GroupInherit::action::defer_emit),

--- a/manager/json-config.hpp
+++ b/manager/json-config.hpp
@@ -38,8 +38,7 @@ class JsonConfig
      * @param[in] bus       - The D-Bus object
      * @param[in] event     - sd event handler
      */
-    JsonConfig(sdbusplus::bus::bus& bus, sdeventplus::Event& event) :
-        event(event)
+    JsonConfig(sdbusplus::bus_t& bus, sdeventplus::Event& event) : event(event)
     {
         match = std::make_unique<sdbusplus::bus::match_t>(
             bus,
@@ -96,7 +95,7 @@ class JsonConfig
      *
      * @param[in] msg - The D-Bus message contents
      */
-    void ifacesAddedCallback(sdbusplus::message::message& msg)
+    void ifacesAddedCallback(sdbusplus::message_t& msg)
     {
         sdbusplus::message::object_path path;
         std::unordered_map<
@@ -227,7 +226,7 @@ class JsonConfig
                     }
                     confFile.clear();
                 }
-                catch (const sdbusplus::exception::exception& e)
+                catch (const sdbusplus::exception_t& e)
                 {
                     // Property unavailable on object.
                     lg2::error(
@@ -239,7 +238,7 @@ class JsonConfig
                 }
             }
         }
-        catch (const sdbusplus::exception::exception& e)
+        catch (const sdbusplus::exception_t& e)
         {
             lg2::error(
                 "Failed to call the SubTreePaths method, ERROR = {ERROR}, INTERFACE = {INTERFACE}",

--- a/manager/lamptest/lamptest.cpp
+++ b/manager/lamptest/lamptest.cpp
@@ -182,7 +182,18 @@ void LampTest::start()
     }
 
     // Get paths of all the Physical LED objects
-    physicalLEDPaths = dBusHandler.getSubTreePaths(PHY_LED_PATH, PHY_LED_IFACE);
+    try
+    {
+        physicalLEDPaths = dBusHandler.getSubTreePaths(PHY_LED_PATH,
+                                                       PHY_LED_IFACE);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::error(
+            "Failed to call the SubTreePaths method: {ERROR}, ledPath: {PATH}, ledInterface: {INTERFACE}",
+            "ERROR", e, "PATH", PHY_LED_PATH, "INTERFACE", PHY_LED_IFACE);
+        return;
+    }
 
     // Get physical LEDs states before lamp test
     storePhysicalLEDsStates();

--- a/manager/lamptest/lamptest.cpp
+++ b/manager/lamptest/lamptest.cpp
@@ -150,7 +150,7 @@ void LampTest::storePhysicalLEDsStates()
             period = std::get<uint16_t>(properties["Period"]);
             dutyOn = std::get<uint8_t>(properties["DutyOn"]);
         }
-        catch (const sdbusplus::exception::exception& e)
+        catch (const sdbusplus::exception_t& e)
         {
             lg2::error(
                 "Failed to get All properties, ERROR = {ERROR}, PATH = {PATH}",
@@ -288,7 +288,7 @@ void LampTest::doHostLampTest(bool value)
                                 "xyz.openbmc_project.Led.Group", "Asserted",
                                 assertedValue);
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         lg2::error(
             "Failed to set Asserted property, ERROR = {ERROR}, PATH = {PATH}",

--- a/manager/lamptest/lamptest.cpp
+++ b/manager/lamptest/lamptest.cpp
@@ -22,7 +22,7 @@ bool LampTest::processLEDUpdates(const Manager::group& ledsAssert,
         // Physical LEDs will be updated during lamp test
         for (const auto& it : ledsDeAssert)
         {
-            std::string path = std::string(PHY_LED_PATH) + it.name;
+            std::string path = std::string(phyLedPath) + it.name;
             auto iter = std::find_if(
                 forceUpdateLEDs.begin(), forceUpdateLEDs.end(),
                 [&path](const auto& name) { return name == path; });
@@ -36,7 +36,7 @@ bool LampTest::processLEDUpdates(const Manager::group& ledsAssert,
 
         for (const auto& it : ledsAssert)
         {
-            std::string path = std::string(PHY_LED_PATH) + it.name;
+            std::string path = std::string(phyLedPath) + it.name;
             auto iter = std::find_if(
                 forceUpdateLEDs.begin(), forceUpdateLEDs.end(),
                 [&path](const auto& name) { return name == path; });
@@ -144,7 +144,7 @@ void LampTest::storePhysicalLEDsStates()
         uint8_t dutyOn{};
         try
         {
-            auto properties = dBusHandler.getAllProperties(path, PHY_LED_IFACE);
+            auto properties = dBusHandler.getAllProperties(path, phyLedIntf);
 
             state = std::get<std::string>(properties["State"]);
             period = std::get<uint16_t>(properties["Period"]);
@@ -184,14 +184,13 @@ void LampTest::start()
     // Get paths of all the Physical LED objects
     try
     {
-        physicalLEDPaths = dBusHandler.getSubTreePaths(PHY_LED_PATH,
-                                                       PHY_LED_IFACE);
+        physicalLEDPaths = dBusHandler.getSubTreePaths(phyLedPath, phyLedIntf);
     }
     catch (const sdbusplus::exception_t& e)
     {
         lg2::error(
             "Failed to call the SubTreePaths method: {ERROR}, ledPath: {PATH}, ledInterface: {INTERFACE}",
-            "ERROR", e, "PATH", PHY_LED_PATH, "INTERFACE", PHY_LED_IFACE);
+            "ERROR", e, "PATH", phyLedPath, "INTERFACE", phyLedIntf);
         return;
     }
 
@@ -325,11 +324,11 @@ void LampTest::getPhysicalLEDNamesFromJson(const fs::path& path)
         const std::vector<std::string> empty{};
         auto forceLEDs = json.value("forceLEDs", empty);
         std::ranges::transform(forceLEDs, std::back_inserter(forceUpdateLEDs),
-                               [](const auto& i) { return PHY_LED_PATH + i; });
+                               [](const auto& i) { return phyLedPath + i; });
 
         auto skipLEDs = json.value("skipLEDs", empty);
         std::ranges::transform(skipLEDs, std::back_inserter(skipUpdateLEDs),
-                               [](const auto& i) { return PHY_LED_PATH + i; });
+                               [](const auto& i) { return phyLedPath + i; });
     }
     catch (const std::exception& e)
     {

--- a/manager/lamptest/lamptest.cpp
+++ b/manager/lamptest/lamptest.cpp
@@ -2,6 +2,8 @@
 
 #include <phosphor-logging/lg2.hpp>
 
+#include <algorithm>
+
 namespace phosphor
 {
 namespace led
@@ -311,16 +313,12 @@ void LampTest::getPhysicalLEDNamesFromJson(const fs::path& path)
         // define the default JSON as empty
         const std::vector<std::string> empty{};
         auto forceLEDs = json.value("forceLEDs", empty);
-        for (auto& member : forceLEDs)
-        {
-            forceUpdateLEDs.push_back(PHY_LED_PATH + member);
-        }
+        std::ranges::transform(forceLEDs, std::back_inserter(forceUpdateLEDs),
+                               [](const auto& i) { return PHY_LED_PATH + i; });
 
         auto skipLEDs = json.value("skipLEDs", empty);
-        for (auto& member : skipLEDs)
-        {
-            skipUpdateLEDs.push_back(PHY_LED_PATH + member);
-        }
+        std::ranges::transform(skipLEDs, std::back_inserter(skipUpdateLEDs),
+                               [](const auto& i) { return PHY_LED_PATH + i; });
     }
     catch (const std::exception& e)
     {

--- a/manager/led-main.cpp
+++ b/manager/led-main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
         // we need to off all the LEDs.
         phosphor::led::utils::DBusHandler dBusHandler;
         std::vector<std::string> pysicalLedPaths = dBusHandler.getSubTreePaths(
-            phosphor::led::PHY_LED_PATH, phosphor::led::PHY_LED_IFACE);
+            phosphor::led::phyLedPath, phosphor::led::phyLedIntf);
 
         for (const auto& path : pysicalLedPaths)
         {
@@ -96,9 +96,9 @@ int main(int argc, char** argv)
         [&bus, &manager, &serialize](
             const std::pair<std::string,
                             std::set<phosphor::led::Layout::LedAction>>& grp) {
-            return std::make_unique<phosphor::led::Group>(bus, grp.first,
-                                                          manager, serialize);
-        });
+        return std::make_unique<phosphor::led::Group>(bus, grp.first, manager,
+                                                      serialize);
+    });
 
     // Attach the bus to sd_event to service user requests
     bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);

--- a/manager/led-main.cpp
+++ b/manager/led-main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     phosphor::led::Manager manager(bus, systemLedMap, event);
 
     /** @brief sd_bus object manager */
-    sdbusplus::server::manager::manager objManager(bus, OBJPATH);
+    sdbusplus::server::manager_t objManager(bus, OBJPATH);
 
 #ifdef USE_LAMP_TEST
     if (std::filesystem::exists(LAMP_TEST_INDICATOR_FILE))

--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -188,14 +188,12 @@ int Manager::drivePhysicalLED(const std::string& objPath, Layout::Action action,
             PropertyValue dutyOnValue{dutyOn};
             PropertyValue periodValue{period};
 
-            dBusHandler.setProperty(objPath, PHY_LED_IFACE, "DutyOn",
-                                    dutyOnValue);
-            dBusHandler.setProperty(objPath, PHY_LED_IFACE, "Period",
-                                    periodValue);
+            dBusHandler.setProperty(objPath, phyLedIntf, "DutyOn", dutyOnValue);
+            dBusHandler.setProperty(objPath, phyLedIntf, "Period", periodValue);
         }
 
         PropertyValue actionValue{getPhysicalAction(action)};
-        dBusHandler.setProperty(objPath, PHY_LED_IFACE, "State", actionValue);
+        dBusHandler.setProperty(objPath, phyLedIntf, "State", actionValue);
     }
     catch (const std::exception& e)
     {
@@ -249,7 +247,7 @@ void Manager::driveLedsHandler(void)
     {
         for (const auto& it : reqLedsDeAssert)
         {
-            std::string objPath = std::string(PHY_LED_PATH) + it.name;
+            std::string objPath = std::string(phyLedPath) + it.name;
             lg2::debug("De-Asserting LED, NAME = {NAME}", "NAME", it.name);
             if (drivePhysicalLED(objPath, Layout::Action::Off, it.dutyOn,
                                  it.period))
@@ -263,7 +261,7 @@ void Manager::driveLedsHandler(void)
     {
         for (const auto& it : reqLedsAssert)
         {
-            std::string objPath = std::string(PHY_LED_PATH) + it.name;
+            std::string objPath = std::string(phyLedPath) + it.name;
             lg2::debug("Asserting LED, NAME = {NAME}", "NAME", it.name);
             if (drivePhysicalLED(objPath, it.action, it.dutyOn, it.period))
             {

--- a/manager/manager.hpp
+++ b/manager/manager.hpp
@@ -148,7 +148,7 @@ class Manager
 
   private:
     /** @brief sdbusplus handler */
-    sdbusplus::bus::bus& bus;
+    sdbusplus::bus_t& bus;
 
     /** Map of physical LED path to service name */
     std::unordered_map<std::string, std::string> phyLeds{};

--- a/manager/manager.hpp
+++ b/manager/manager.hpp
@@ -16,8 +16,8 @@ namespace led
 {
 using namespace phosphor::led::utils;
 
-static constexpr auto PHY_LED_PATH = "/xyz/openbmc_project/led/physical/";
-static constexpr auto PHY_LED_IFACE = "xyz.openbmc_project.Led.Physical";
+static constexpr auto phyLedPath = "/xyz/openbmc_project/led/physical/";
+static constexpr auto phyLedIntf = "xyz.openbmc_project.Led.Physical";
 
 /** @class Manager
  *  @brief Manages group of LEDs and applies action on the elements of group

--- a/manager/serialize.hpp
+++ b/manager/serialize.hpp
@@ -21,7 +21,7 @@ using SavedGroups = std::set<std::string>;
 class Serialize
 {
   public:
-    Serialize(const fs::path& path) : path(path)
+    explicit Serialize(const fs::path& path) : path(path)
     {
         restoreGroups();
     }

--- a/meson.build
+++ b/meson.build
@@ -55,10 +55,10 @@ realpath_prog = find_program('realpath')
 
 cpp = meson.get_compiler('cpp')
 if cpp.has_header('nlohmann/json.hpp')
-    nlohmann_json = declare_dependency()
+    nlohmann_json_dep = declare_dependency()
 else
     subproject('nlohmann', required: false)
-    nlohmann_json = declare_dependency(
+    nlohmann_json_dep = declare_dependency(
         include_directories: [
             'subprojects/nlohmann/single_include',
             'subprojects/nlohmann/single_include/nlohmann',
@@ -74,6 +74,7 @@ else
         fallback: [ 'CLI11', 'CLI11_dep' ],
     )
 endif
+
 
 #Get Cereal dependency.
 cereal_dep = dependency('cereal', required: false)
@@ -98,7 +99,8 @@ deps = [
     sdeventplus_dep,
     phosphor_logging_dep,
     phosphor_dbus_interfaces_dep,
-    nlohmann_json
+    nlohmann_json_dep,
+    cereal_dep,
 ]
 
 subdir('manager')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/subprojects/cereal.wrap
+++ b/subprojects/cereal.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/USCiLab/cereal.git
+revision = HEAD
+# need at least for C++20 fixes 3e4d1b84cab4891368d2179a61a7ba06a5693e7f

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -11,7 +11,7 @@ using namespace phosphor::led;
 class LedTest : public ::testing::Test
 {
   public:
-    sdbusplus::bus::bus bus;
+    sdbusplus::bus_t bus;
     LedTest() : bus(sdbusplus::bus::new_default())
     {
         // Nothing here

--- a/utils.cpp
+++ b/utils.cpp
@@ -18,8 +18,8 @@ const std::string DBusHandler::getService(const std::string& path,
 
     auto& bus = DBusHandler::getBus();
 
-    auto mapper = bus.new_method_call(MAPPER_BUSNAME, MAPPER_OBJ_PATH,
-                                      MAPPER_IFACE, "GetObject");
+    auto mapper = bus.new_method_call(mapperBusName, mapperObjPath, mapperIntf,
+                                      "GetObject");
     mapper.append(path, InterfaceList({interface}));
 
     auto mapperResponseMsg = bus.call(mapper);
@@ -51,7 +51,7 @@ const PropertyMap
     }
 
     auto method = bus.new_method_call(service.c_str(), objectPath.c_str(),
-                                      DBUS_PROPERTY_IFACE, "GetAll");
+                                      proIntf, "GetAll");
     method.append(interface);
 
     auto reply = bus.call(method);
@@ -76,7 +76,7 @@ const PropertyValue
     }
 
     auto method = bus.new_method_call(service.c_str(), objectPath.c_str(),
-                                      DBUS_PROPERTY_IFACE, "Get");
+                                      proIntf, "Get");
     method.append(interface, propertyName);
 
     auto reply = bus.call(method);
@@ -99,7 +99,7 @@ void DBusHandler::setProperty(const std::string& objectPath,
     }
 
     auto method = bus.new_method_call(service.c_str(), objectPath.c_str(),
-                                      DBUS_PROPERTY_IFACE, "Set");
+                                      proIntf, "Set");
     method.append(interface.c_str(), propertyName.c_str(), value);
 
     bus.call_noreply(method);
@@ -113,8 +113,8 @@ const std::vector<std::string>
 
     auto& bus = DBusHandler::getBus();
 
-    auto method = bus.new_method_call(MAPPER_BUSNAME, MAPPER_OBJ_PATH,
-                                      MAPPER_IFACE, "GetSubTreePaths");
+    auto method = bus.new_method_call(mapperBusName, mapperObjPath, mapperIntf,
+                                      "GetSubTreePaths");
     method.append(objectPath.c_str());
     method.append(0); // Depth 0 to search all
     method.append(std::vector<std::string>({interface.c_str()}));

--- a/utils.hpp
+++ b/utils.hpp
@@ -10,10 +10,10 @@ namespace led
 {
 namespace utils
 {
-constexpr auto MAPPER_BUSNAME = "xyz.openbmc_project.ObjectMapper";
-constexpr auto MAPPER_OBJ_PATH = "/xyz/openbmc_project/object_mapper";
-constexpr auto MAPPER_IFACE = "xyz.openbmc_project.ObjectMapper";
-constexpr auto DBUS_PROPERTY_IFACE = "org.freedesktop.DBus.Properties";
+static constexpr auto mapperBusName = "xyz.openbmc_project.ObjectMapper";
+static constexpr auto mapperObjPath = "/xyz/openbmc_project/object_mapper";
+static constexpr auto mapperIntf = "xyz.openbmc_project.ObjectMapper";
+static constexpr auto proIntf = "org.freedesktop.DBus.Properties";
 
 using AssociationTuple = std::tuple<std::string, std::string, std::string>;
 using AssociationsProperty = std::vector<AssociationTuple>;

--- a/utils.hpp
+++ b/utils.hpp
@@ -68,7 +68,7 @@ class DBusHandler
      *
      *  @return The Map to constructs all properties values
      *
-     *  @throw sdbusplus::exception::exception when it fails
+     *  @throw sdbusplus::exception_t when it fails
      */
     const PropertyMap getAllProperties(const std::string& objectPath,
                                        const std::string& interface) const;
@@ -81,7 +81,7 @@ class DBusHandler
      *
      *  @return The value of the property(type: variant)
      *
-     *  @throw sdbusplus::exception::exception when it fails
+     *  @throw sdbusplus::exception_t when it fails
      */
     const PropertyValue getProperty(const std::string& objectPath,
                                     const std::string& interface,
@@ -94,7 +94,7 @@ class DBusHandler
      *  @param[in] propertyName     -   D-Bus property name
      *  @param[in] value            -   The value to be set
      *
-     *  @throw sdbusplus::exception::exception when it fails
+     *  @throw sdbusplus::exception_t when it fails
      */
     void setProperty(const std::string& objectPath,
                      const std::string& interface,


### PR DESCRIPTION
Pulled  below commits from upstream.

- 1f0b715 Use the lower camel case of the C++ standard.
- 785f505 lamp test: Fix calling GetSubTreePaths method
- b4c82cf support sdbusplus::message::object_path.
- 3e073ba sdbusplus: use shorter type aliases
- fccfac9 parse_led: format with black
- d1c1f0e meson: add proper cereal dependency
- c5e0f31 Fix some warnings by cppcheck

Tested Patch on HW physically .