### PR TITLE
Led Upstream Sync

### DIFF
--- a/manager/group.cpp
+++ b/manager/group.cpp
@@ -1,7 +1,7 @@
 #include "config.h"
 
 #include "group.hpp"
-
+#include "ledlayout.hpp"
 #include <sdbusplus/message.hpp>
 
 #ifdef IBM_SAI
@@ -36,8 +36,8 @@ bool Group::asserted(bool value)
     }
 
     // Introducing these to enable gtest.
-    Manager::group ledsAssert{};
-    Manager::group ledsDeAssert{};
+    ActionSet ledsAssert{};
+    ActionSet ledsDeAssert{};
 
     // Group management is handled by Manager. The populated leds* sets are not
     // really used by production code. They are there to enable gtest for

--- a/manager/json-parser.hpp
+++ b/manager/json-parser.hpp
@@ -15,8 +15,6 @@
 namespace fs = std::filesystem;
 
 using Json = nlohmann::json;
-using LedAction = std::set<phosphor::led::Layout::LedAction>;
-using LedMap = std::unordered_map<std::string, LedAction>;
 
 // Priority for a particular LED needs to stay SAME across all groups
 // phosphor::led::Layout::Action can only be one of `Blink` and `On`
@@ -62,8 +60,8 @@ phosphor::led::Layout::Action getAction(const std::string& action)
 {
     assert(action == "On" || action == "Blink");
 
-    return action == "Blink" ? phosphor::led::Layout::Blink
-                             : phosphor::led::Layout::On;
+    return action == "Blink" ? phosphor::led::Layout::Action::Blink
+                             : phosphor::led::Layout::Action::On;
 }
 
 /** @brief Validate the Priority of an LED is same across ALL groups
@@ -99,11 +97,11 @@ void validatePriority(const std::string& name,
 
 /** @brief Load JSON config and return led map (JSON version 1)
  *
- *  @return LedMap - Generated an std::unordered_map of LedAction
+ *  @return phosphor::led::GroupMap
  */
-const LedMap loadJsonConfigV1(const Json& json)
+const phosphor::led::GroupMap loadJsonConfigV1(const Json& json)
 {
-    LedMap ledMap{};
+    phosphor::led::GroupMap ledMap{};
     PriorityMap priorityMap{};
 
     // define the default JSON as empty
@@ -117,7 +115,7 @@ const LedMap loadJsonConfigV1(const Json& json)
         auto objpath = tmpPath.string();
         auto members = entry.value("members", empty);
 
-        LedAction ledActions{};
+        phosphor::led::ActionSet ledActions{};
         for (const auto& member : members)
         {
             auto name = member.value("Name", "");
@@ -146,10 +144,9 @@ const LedMap loadJsonConfigV1(const Json& json)
 }
 
 /** @brief Load JSON config and return led map
- *
- *  @return LedMap - Generated an std::map of LedAction
+ *  @return phosphor::led::GroupMap
  */
-const LedMap loadJsonConfig(const fs::path& path)
+const phosphor::led::GroupMap loadJsonConfig(const fs::path& path)
 {
     auto json = readJson(path);
 
@@ -165,18 +162,18 @@ const LedMap loadJsonConfig(const fs::path& path)
             throw std::runtime_error("Unsupported version");
     }
 
-    return LedMap{};
+    return phosphor::led::GroupMap{};
 }
 
 /** @brief Get led map from LED groups JSON config
  *
  *  @param[in] config - Path to the JSON config.
- *  @return LedMap - Generated an std::unordered_map of LedAction
+ *  @return phosphor::led::GroupMap
  *
  *  @note if config is an empty string, daemon will interrogate dbus for
  *        compatible strings.
  */
-const LedMap getSystemLedMap(fs::path config)
+const phosphor::led::GroupMap getSystemLedMap(fs::path config)
 {
     if (config.empty())
     {

--- a/manager/lamptest/lamptest.cpp
+++ b/manager/lamptest/lamptest.cpp
@@ -9,8 +9,8 @@ namespace led
 
 using Json = nlohmann::json;
 
-bool LampTest::processLEDUpdates(const Manager::group& ledsAssert,
-                                 const Manager::group& ledsDeAssert)
+bool LampTest::processLEDUpdates(const ActionSet& ledsAssert,
+                                 const ActionSet& ledsDeAssert)
 {
     // If the physical LED status is updated during the lamp test, it should be
     // saved to Queue, and the queue will be processed after the lamp test is
@@ -94,15 +94,15 @@ void LampTest::stop()
 
 Layout::Action LampTest::getActionFromString(const std::string& str)
 {
-    Layout::Action action = Layout::Off;
+    Layout::Action action = Layout::Action::Off;
 
     if (str == "xyz.openbmc_project.Led.Physical.Action.On")
     {
-        action = Layout::On;
+        action = Layout::Action::On;
     }
     else if (str == "xyz.openbmc_project.Led.Physical.Action.Blink")
     {
-        action = Layout::Blink;
+        action = Layout::Action::Blink;
     }
 
     return action;
@@ -157,10 +157,10 @@ void LampTest::storePhysicalLEDsStates()
         }
 
         phosphor::led::Layout::Action action = getActionFromString(state);
-        if (action != phosphor::led::Layout::Off)
+        if (action != phosphor::led::Layout::Action::Off)
         {
             phosphor::led::Layout::LedAction ledAction{
-                name, action, dutyOn, period, phosphor::led::Layout::On};
+                name, action, dutyOn, period, phosphor::led::Layout::Action::On};
             physicalLEDStatesPriorToLampTest.emplace(ledAction);
         }
     }
@@ -264,7 +264,7 @@ bool LampTest::requestHandler(Group* group, bool value)
 void LampTest::restorePhysicalLedStates()
 {
     // restore physical LEDs states before lamp test
-    Manager::group ledsDeAssert{};
+    ActionSet ledsDeAssert{};
     manager.driveLEDs(physicalLEDStatesPriorToLampTest, ledsDeAssert);
     physicalLEDStatesPriorToLampTest.clear();
 

--- a/manager/lamptest/lamptest.hpp
+++ b/manager/lamptest/lamptest.hpp
@@ -4,7 +4,7 @@
 
 #include "group.hpp"
 #include "manager.hpp"
-
+#include "ledlayout.hpp"
 #include <nlohmann/json.hpp>
 #include <sdeventplus/utility/timer.hpp>
 
@@ -70,8 +70,8 @@ class LampTest
      *
      *  @return Is running lamp test, true running
      */
-    bool processLEDUpdates(const Manager::group& ledsAssert,
-                           const Manager::group& ledsDeAssert);
+    bool processLEDUpdates(const ActionSet& ledsAssert,
+                           const ActionSet& ledsDeAssert);
 
   private:
     /** @brief Timer used for LEDs lamp test period */
@@ -90,14 +90,14 @@ class LampTest
     std::vector<std::string> physicalLEDPaths;
 
     /** @brief Queue to save LED states during lamp test */
-    std::queue<std::pair<Manager::group, Manager::group>>
+    std::queue<std::pair<ActionSet, ActionSet>>
         updatedLEDsDuringLampTest;
 
     /** @brief Get state of the lamp test operation */
     bool isLampTestRunning{false};
 
     /** @brief Physical LED states prior to lamp test */
-    Manager::group physicalLEDStatesPriorToLampTest;
+    ActionSet physicalLEDStatesPriorToLampTest;
 
     /** @brief Vector of names of physical LEDs, whose changes will be forcibly
      *         updated even during lamp test. */

--- a/manager/led-main.cpp
+++ b/manager/led-main.cpp
@@ -96,6 +96,12 @@ int main(int argc, char** argv)
             bus, grp.first, manager, serialize));
     }
 
+      std::ranges::transform(systemLedMap, std::back_inserter(groups),
+                           [&bus, &manager, &serialize](auto& grp) {
+                               return std::make_unique<phosphor::led::Group>(
+                                   bus, grp.first, manager, serialize);
+			       });
+
     // Attach the bus to sd_event to service user requests
     bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
 

--- a/manager/ledlayout.hpp
+++ b/manager/ledlayout.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <xyz/openbmc_project/Led/Physical/server.hpp>
 #include <cstdint>
 #include <set>
 #include <string>
@@ -14,15 +15,8 @@ namespace led
  */
 namespace Layout
 {
-/** @brief Define possible actions on a given LED.
- *  For the BLINK operation, follow 50-50 duty cycle
- */
-enum Action
-{
-    Off,
-    On,
-    Blink,
-};
+
+using Action = sdbusplus::xyz::openbmc_project::Led::server::Physical::Action;
 
 /** @brief Name of the LED and it's proposed action.
  *  This structure is supplied as configuration at build time
@@ -55,5 +49,9 @@ struct LedAction
     }
 };
 } // namespace Layout
+
+using ActionSet = std::set<Layout::LedAction>;
+using GroupMap = std::unordered_map<std::string, ActionSet>;
+
 } // namespace led
 } // namespace phosphor

--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -16,7 +16,7 @@ namespace led
 
 // Assert -or- De-assert
 bool Manager::setGroupState(const std::string& path, bool assert,
-                            group& ledsAssert, group& ledsDeAssert)
+                            ActionSet& ledsAssert, ActionSet& ledsDeAssert)
 {
     if (assert)
     {
@@ -31,7 +31,7 @@ bool Manager::setGroupState(const std::string& path, bool assert,
     }
 
     // This will contain the union of what's already in the asserted group
-    group desiredState{};
+    ActionSet desiredState{};
     for (const auto& grp : assertedGroups)
     {
         desiredState.insert(grp->cbegin(), grp->cend());
@@ -39,7 +39,7 @@ bool Manager::setGroupState(const std::string& path, bool assert,
 
     // Find difference between Combined and Desired to identify
     // which LEDs are getting altered
-    group transient{};
+    ActionSet transient{};
     std::set_difference(combinedState.begin(), combinedState.end(),
                         desiredState.begin(), desiredState.end(),
                         std::inserter(transient, transient.begin()), ledComp);
@@ -47,7 +47,7 @@ bool Manager::setGroupState(const std::string& path, bool assert,
     {
         // Find common LEDs between transient and Desired to know if some LEDs
         // are changing state and not really getting DeAsserted
-        group ledsTransient{};
+        ActionSet ledsTransient{};
         std::set_intersection(
             transient.begin(), transient.end(), desiredState.begin(),
             desiredState.end(),
@@ -79,7 +79,7 @@ bool Manager::setGroupState(const std::string& path, bool assert,
 
     // Now LEDs that are to be Asserted. These could either be fresh asserts
     // -or- change between [On]<-->[Blink]
-    group temp{};
+    ActionSet temp{};
     std::unique_copy(desiredState.begin(), desiredState.end(),
                      std::inserter(temp, temp.begin()), ledEqual);
     if (temp.size())
@@ -100,13 +100,13 @@ bool Manager::setGroupState(const std::string& path, bool assert,
 }
 
 void Manager::setLampTestCallBack(
-    std::function<bool(group& ledsAssert, group& ledsDeAssert)> callBack)
+    std::function<bool(ActionSet& ledsAssert, ActionSet& ledsDeAssert)> callBack)
 {
     lampTestCallBack = callBack;
 }
 
 /** @brief Run through the map and apply action on the LEDs */
-void Manager::driveLEDs(group& ledsAssert, group& ledsDeAssert)
+void Manager::driveLEDs(ActionSet& ledsAssert, ActionSet& ledsDeAssert)
 {
 #ifdef USE_LAMP_TEST
     // Use the lampTestCallBack method and trigger the callback method in the

--- a/manager/manager.hpp
+++ b/manager/manager.hpp
@@ -68,18 +68,15 @@ class Manager
         return left.name == right.name;
     }
 
-    using group = std::set<phosphor::led::Layout::LedAction>;
-    using LedLayout = std::unordered_map<std::string, group>;
-
     /** @brief static global map constructed at compile time */
-    const LedLayout& ledMap;
+    const GroupMap& ledMap;
 
     /** @brief Refer the user supplied LED layout and sdbusplus handler
      *
      *  @param [in] bus       - sdbusplus handler
-     *  @param [in] LedLayout - LEDs group layout
+     *  @param [in] GroupMap - LEDs group layout
      */
-    Manager(sdbusplus::bus::bus& bus, const LedLayout& ledLayout) :
+    Manager(sdbusplus::bus::bus& bus, const GroupMap& ledLayout) :
         ledMap(ledLayout), bus(bus)
     {
         // Nothing here
@@ -95,8 +92,8 @@ class Manager
      *
      *  @return                   -  Success or exception thrown
      */
-    bool setGroupState(const std::string& path, bool assert, group& ledsAssert,
-                       group& ledsDeAssert);
+    bool setGroupState(const std::string& path, bool assert, ActionSet& ledsAssert,
+                       ActionSet& ledsDeAssert);
 
     /** @brief Finds the set of LEDs to operate on and executes action
      *
@@ -106,7 +103,7 @@ class Manager
      *
      *  @return: None
      */
-    void driveLEDs(group& ledsAssert, group& ledsDeAssert);
+    void driveLEDs(ActionSet& ledsAssert, ActionSet& ledsDeAssert);
 
     /** @brief Chooses appropriate action to be triggered on physical LED
      *  and calls into function that applies the actual action.
@@ -124,7 +121,7 @@ class Manager
      *  @param[in]  callBack   -  Custom callback when enabled lamp test
      */
     void setLampTestCallBack(
-        std::function<bool(group& ledsAssert, group& ledsDeAssert)> callBack);
+        std::function<bool(ActionSet& ledsAssert, ActionSet& ledsDeAssert)> callBack);
 
     /** @brief Check for asserted state by group path.
      *
@@ -148,18 +145,18 @@ class Manager
     DBusHandler dBusHandler;
 
     /** @brief Pointers to groups that are in asserted state */
-    std::set<const group*> assertedGroups;
+    std::set<const ActionSet*> assertedGroups;
 
     /** @brief Contains the highest priority actions for all
      *         asserted LEDs.
      */
-    group currentState;
+    ActionSet currentState;
 
     /** @brief Contains the set of all actions for asserted LEDs */
-    group combinedState;
+    ActionSet combinedState;
 
     /** @brief Custom callback when enabled lamp test */
-    std::function<bool(group& ledsAssert, group& ledsDeAssert)>
+    std::function<bool(ActionSet& ledsAssert, ActionSet& ledsDeAssert)>
         lampTestCallBack;
 
     /** @brief Returns action string based on enum

--- a/scripts/parse_led.py
+++ b/scripts/parse_led.py
@@ -48,8 +48,7 @@ if __name__ == "__main__":
         ofile.write("/* !!! WARNING: This is a GENERATED Code..")
         ofile.write("Please do NOT Edit !!! */\n\n")
 
-        ofile.write("static const std::unordered_map<std::string,")
-        ofile.write("std::set<phosphor::led::Layout::LedAction>>")
+        ofile.write("static const phosphor::led::GroupMap")
         ofile.write(" systemLedMap = {\n\n")
         for group in list(ifile.keys()):
             # This section generates an std::unordered_map of LedGroupNames to

--- a/test/led-test-map.hpp
+++ b/test/led-test-map.hpp
@@ -1,12 +1,6 @@
 #include "ledlayout.hpp"
 
-#include <set>
-#include <string>
-#include <unordered_map>
-
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    singleLedOn = {
+static const phosphor::led::GroupMap singleLedOn = {
         {"/xyz/openbmc_project/ledmanager/groups/SingleLed",
          {
              {"One", phosphor::led::Layout::On, 0, 0,
@@ -14,9 +8,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    singleLedBlink = {
+static const phosphor::led::GroupMap singleLedBlink = {
         {"/xyz/openbmc_project/ledmanager/groups/SingleLed",
          {
              {"One", phosphor::led::Layout::Blink, 0, 0,
@@ -24,9 +16,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    singleLedBlinkOverrideOn = {
+static const phosphor::led::GroupMap singleLedBlinkOverrideOn = {
         {"/xyz/openbmc_project/ledmanager/groups/SingleLed",
          {
              {"One", phosphor::led::Layout::Blink, 0, 0,
@@ -34,9 +24,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    multipleLedsOn = {
+static const phosphor::led::GroupMap multipleLedsOn = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLeds",
          {
              {"One", phosphor::led::Layout::On, 0, 0,
@@ -48,9 +36,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    multipleLedsBlink = {
+static const phosphor::led::GroupMap multipleLedsBlink = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLeds",
          {
              {"One", phosphor::led::Layout::Blink, 0, 0,
@@ -62,9 +48,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    multipleLedsOnAndBlink = {
+static const phosphor::led::GroupMap multipleLedsOnAndBlink = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsMix",
          {
              {"One", phosphor::led::Layout::Blink, 0, 0,
@@ -80,9 +64,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    twoGroupsWithDistinctLEDsOn = {
+static const phosphor::led::GroupMap twoGroupsWithDistinctLEDsOn = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
              {"One", phosphor::led::Layout::On, 0, 0,
@@ -103,9 +85,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    twoGroupsWithOneComonLEDOn = {
+static const phosphor::led::GroupMap twoGroupsWithOneComonLEDOn = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
              {"One", phosphor::led::Layout::On, 0, 0,
@@ -126,8 +106,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
+static const phosphor::led::GroupMap
     twoGroupsWithOneComonLEDOnOneLEDBlinkPriority = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -149,9 +128,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    twoGroupsWithOneComonLEDOnPriority = {
+static const phosphor::led::GroupMap twoGroupsWithOneComonLEDOnPriority = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
              {"One", phosphor::led::Layout::On, 0, 0,
@@ -172,9 +149,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
-    twoGroupsWithMultiplComonLEDOn = {
+static const phosphor::led::GroupMap twoGroupsWithMultiplComonLEDOn = {        
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
              {"One", phosphor::led::Layout::On, 0, 0,
@@ -197,8 +172,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
+static const phosphor::led::GroupMap
     twoGroupsWithMultipleComonLEDInDifferentState = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {
@@ -224,8 +198,7 @@ static const std::unordered_map<std::string,
          }},
 };
 
-static const std::unordered_map<std::string,
-                                std::set<phosphor::led::Layout::LedAction>>
+static const phosphor::led::GroupMap
     twoGroupsWithMultipleComonLEDInDifferentStateDiffPriority = {
         {"/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet",
          {

--- a/test/utest-led-json.cpp
+++ b/test/utest-led-json.cpp
@@ -5,7 +5,7 @@
 TEST(loadJsonConfig, testGoodPath)
 {
     static constexpr auto jsonPath = "config/led-group-config.json";
-    LedMap ledMap = loadJsonConfig(jsonPath);
+    auto ledMap = loadJsonConfig(jsonPath);
 
     std::string objPath = "/xyz/openbmc_project/led/groups";
     std::string bmcBooted = objPath + "/bmc_booted";
@@ -16,9 +16,9 @@ TEST(loadJsonConfig, testGoodPath)
     ASSERT_EQ(ledMap.contains(powerOn), true);
     ASSERT_EQ(ledMap.contains(enclosureIdentify), true);
 
-    LedAction bmcBootedActions = ledMap.at(bmcBooted);
-    LedAction powerOnActions = ledMap.at(powerOn);
-    LedAction enclosureIdentifyActions = ledMap.at(enclosureIdentify);
+    auto& bmcBootedActions = ledMap.at(bmcBooted);
+    auto& powerOnActions = ledMap.at(powerOn);
+    auto& enclosureIdentifyActions = ledMap.at(enclosureIdentify);
 
     for (const auto& group : bmcBootedActions)
     {

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -28,8 +28,8 @@ TEST_F(LedTest, assertSingleLedOn)
     Manager manager(bus, singleLedOn);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/SingleLed";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -37,7 +37,7 @@ TEST_F(LedTest, assertSingleLedOn)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
         };
@@ -45,7 +45,7 @@ TEST_F(LedTest, assertSingleLedOn)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -59,8 +59,8 @@ TEST_F(LedTest, assertSingleLedBlink)
     Manager manager(bus, singleLedBlink);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/SingleLed";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -68,7 +68,7 @@ TEST_F(LedTest, assertSingleLedBlink)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::Blink},
         };
@@ -76,7 +76,7 @@ TEST_F(LedTest, assertSingleLedBlink)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -90,8 +90,8 @@ TEST_F(LedTest, assertSingleLedOnAndreAssert)
     Manager manager(bus, singleLedOn);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/SingleLed";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -99,7 +99,7 @@ TEST_F(LedTest, assertSingleLedOnAndreAssert)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
         };
@@ -107,7 +107,7 @@ TEST_F(LedTest, assertSingleLedOnAndreAssert)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -115,8 +115,8 @@ TEST_F(LedTest, assertSingleLedOnAndreAssert)
     }
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/SingleLed";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -134,8 +134,8 @@ TEST_F(LedTest, assertMultipleLedOn)
     Manager manager(bus, multipleLedsOn);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLeds";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -143,7 +143,7 @@ TEST_F(LedTest, assertMultipleLedOn)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::On, 0, 0,
@@ -153,7 +153,7 @@ TEST_F(LedTest, assertMultipleLedOn)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -167,8 +167,8 @@ TEST_F(LedTest, assertMultipleLedBlink)
     Manager manager(bus, multipleLedsBlink);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLeds";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -176,7 +176,7 @@ TEST_F(LedTest, assertMultipleLedBlink)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::Blink},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
@@ -188,7 +188,7 @@ TEST_F(LedTest, assertMultipleLedBlink)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -202,8 +202,8 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssert)
     Manager manager(bus, multipleLedsBlink);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLeds";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -211,7 +211,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssert)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::Blink},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
@@ -223,7 +223,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssert)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -231,8 +231,8 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssert)
     }
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLeds";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -240,7 +240,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssert)
         EXPECT_EQ(false, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::Blink},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
@@ -252,7 +252,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssert)
         EXPECT_EQ(0, ledsAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -266,8 +266,8 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssertTwice)
     Manager manager(bus, multipleLedsBlink);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLeds";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -275,7 +275,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssertTwice)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::Blink},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
@@ -287,7 +287,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssertTwice)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -295,8 +295,8 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssertTwice)
     }
     {
         // DeAssert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLeds";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -304,7 +304,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssertTwice)
         EXPECT_EQ(false, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::Blink},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
@@ -316,7 +316,7 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssertTwice)
         EXPECT_EQ(0, ledsAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -324,8 +324,8 @@ TEST_F(LedTest, assertMultipleLedBlinkAndDeAssertTwice)
     }
     {
         // DeAssert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLeds";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -342,8 +342,8 @@ TEST_F(LedTest, assertMultipleLedOnAndBlink)
     Manager manager(bus, multipleLedsOnAndBlink);
     {
         // Assert the LEDs.
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsMix";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -351,7 +351,7 @@ TEST_F(LedTest, assertMultipleLedOnAndBlink)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::Blink},
             {"Two", phosphor::led::Layout::On, 0, 0,
@@ -367,7 +367,7 @@ TEST_F(LedTest, assertMultipleLedOnAndBlink)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -381,8 +381,8 @@ TEST_F(LedTest, assertTwoGroupsOnWithDistinctLEDOn)
     Manager manager(bus, twoGroupsWithDistinctLEDsOn);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -390,7 +390,7 @@ TEST_F(LedTest, assertTwoGroupsOnWithDistinctLEDOn)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -401,7 +401,7 @@ TEST_F(LedTest, assertTwoGroupsOnWithDistinctLEDOn)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -409,8 +409,8 @@ TEST_F(LedTest, assertTwoGroupsOnWithDistinctLEDOn)
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -418,7 +418,7 @@ TEST_F(LedTest, assertTwoGroupsOnWithDistinctLEDOn)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
             {"Five", phosphor::led::Layout::On, 0, 0,
@@ -429,7 +429,7 @@ TEST_F(LedTest, assertTwoGroupsOnWithDistinctLEDOn)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -443,8 +443,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOn)
     Manager manager(bus, twoGroupsWithOneComonLEDOn);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -452,7 +452,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOn)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::On, 0, 0,
@@ -462,7 +462,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOn)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -470,8 +470,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOn)
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -479,7 +479,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOn)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -488,7 +488,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOn)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -503,8 +503,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
     Manager manager(bus, twoGroupsWithOneComonLEDOnOneLEDBlinkPriority);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -512,7 +512,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::Blink, 0, 0,
@@ -522,7 +522,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -530,8 +530,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -540,7 +540,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
 
         // Need just the ledsAssserted populated with these.
         // Does not action on [Three] since  priority is [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -549,7 +549,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -557,8 +557,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
     }
     {
         // De-Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -566,7 +566,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
         EXPECT_EQ(false, result);
 
         // Need just the ledsDeAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -576,7 +576,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertB)
 
         // difference of refDeAssert and ledsDeAssert must be null.
         // [Three] is not touched since its already [Blink]
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -591,8 +591,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
     Manager manager(bus, twoGroupsWithOneComonLEDOnOneLEDBlinkPriority);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -600,7 +600,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::Blink, 0, 0,
@@ -610,7 +610,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -618,8 +618,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -628,7 +628,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
 
         // Need just the ledsAssserted populated with these.
         // [Three] does not get actioned since it has Blink priority
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -637,7 +637,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -645,8 +645,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
     }
     {
         // De-Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -654,28 +654,28 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDBlinkPriorityAndDeAssertA)
         EXPECT_EQ(false, result);
 
         // Need just the ledsDeAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
         };
         EXPECT_EQ(refDeAssert.size(), ledsDeAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
         EXPECT_EQ(0, temp.size());
 
         // Need just the ledsAssert populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Three", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp1{};
+        ActionSet temp1{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp1, temp1.begin()));
@@ -690,8 +690,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
     Manager manager(bus, twoGroupsWithOneComonLEDOnPriority);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -699,7 +699,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::Blink, 0, 0,
@@ -709,7 +709,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -717,8 +717,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -727,7 +727,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
 
         // Need just the ledsAssserted populated with these.
         // Three is set to ON due to ON priority.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Three", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
@@ -738,15 +738,15 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
     }
     {
         // De-Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -755,7 +755,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
 
         // Need just the ledsDeAssserted populated with these.
         // [Three] stays in [On] since [B] has it [On]
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
         };
@@ -763,7 +763,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertA)
         EXPECT_EQ(0, ledsAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -778,8 +778,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
     Manager manager(bus, twoGroupsWithOneComonLEDOnPriority);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -787,7 +787,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::Blink, 0, 0,
@@ -797,7 +797,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -805,8 +805,8 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -815,7 +815,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
 
         // Need just the ledsAssserted populated with these.
         // Three is set to ON due to ON priority.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Three", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
@@ -826,15 +826,15 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
     }
     {
         // De-Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -842,7 +842,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
         EXPECT_EQ(false, result);
 
         // Need just the ledsDeAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -850,7 +850,7 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
         EXPECT_EQ(refDeAssert.size(), ledsDeAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -858,14 +858,14 @@ TEST_F(LedTest, asserttwoGroupsWithOneComonLEDOnOneLEDOnPriorityAndDeAssertB)
 
         // Need just the ledsAssert populated with these.
         // Since [Three] stood [On], need to go back to [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Three", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp1{};
+        ActionSet temp1{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -879,8 +879,8 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
     Manager manager(bus, twoGroupsWithMultiplComonLEDOn);
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -888,7 +888,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::On, 0, 0,
@@ -900,7 +900,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -908,8 +908,8 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
     }
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -917,14 +917,14 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -932,8 +932,8 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
     }
     {
         // De-Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -941,7 +941,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
         EXPECT_EQ(false, result);
 
         // Need just the ledsDeAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Seven", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -950,7 +950,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultiplComonLEDOnAndDeAssert)
         EXPECT_EQ(0, ledsAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -964,8 +964,8 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateBandA)
     Manager manager(bus, twoGroupsWithMultipleComonLEDInDifferentState);
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -973,7 +973,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateBandA)
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
@@ -985,7 +985,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateBandA)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -993,8 +993,8 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateBandA)
     }
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1004,7 +1004,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateBandA)
         // Need just the ledsAssserted populated with these
         // [Two] remains [On] due to higher priority.
         // [Three] remains [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1013,7 +1013,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateBandA)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1027,8 +1027,8 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateAtoB)
     Manager manager(bus, twoGroupsWithMultipleComonLEDInDifferentState);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1037,7 +1037,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateAtoB)
 
         // Need just the ledsAssserted populated with these.'Two' gets to Blink
         // due to higher priority.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
@@ -1050,7 +1050,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateAtoB)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1058,8 +1058,8 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateAtoB)
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1069,7 +1069,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateAtoB)
         // Need just the ledsAssserted populated with these.
         // [Three] remains [Blink] from previous
         // [Two] moves to [On] from [Blink] due to [On] priority
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Five", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1079,7 +1079,7 @@ TEST_F(LedTest, assertTwoGroupsWithMultipleComonLEDInDifferentStateAtoB)
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1096,8 +1096,8 @@ TEST_F(LedTest,
     Manager manager(bus, twoGroupsWithMultipleComonLEDInDifferentState);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1105,7 +1105,7 @@ TEST_F(LedTest,
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
@@ -1118,7 +1118,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1126,8 +1126,8 @@ TEST_F(LedTest,
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1137,7 +1137,7 @@ TEST_F(LedTest,
         // Need just the ledsAssserted populated with these.
         // [Two] turns [On] due to priority
         // [Three] remains [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Five", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1147,7 +1147,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1155,8 +1155,8 @@ TEST_F(LedTest,
     }
     {
         // DeAssert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1164,7 +1164,7 @@ TEST_F(LedTest,
         EXPECT_EQ(false, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"Five", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -1172,7 +1172,7 @@ TEST_F(LedTest,
         EXPECT_EQ(refDeAssert.size(), ledsDeAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1180,14 +1180,14 @@ TEST_F(LedTest,
 
         // Need just the ledsAssert populated with these.
         // [Two] will go back to [Blink] from [On]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp1{};
+        ActionSet temp1{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp1, temp1.begin()));
@@ -1195,8 +1195,8 @@ TEST_F(LedTest,
     }
     {
         // DeAssert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1204,7 +1204,7 @@ TEST_F(LedTest,
         EXPECT_EQ(false, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
@@ -1217,7 +1217,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1225,8 +1225,8 @@ TEST_F(LedTest,
     }
     {
         // DeAssert Set-A again and make sure we get all empty
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1247,8 +1247,8 @@ TEST_F(LedTest,
                     twoGroupsWithMultipleComonLEDInDifferentStateDiffPriority);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1256,7 +1256,7 @@ TEST_F(LedTest,
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
@@ -1271,7 +1271,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1279,8 +1279,8 @@ TEST_F(LedTest,
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1291,7 +1291,7 @@ TEST_F(LedTest,
         // [Two] gets to [ON] due to higher priority.
         // [Three] remains on since it never was in [Blink] before
         // [Ten] remains [Blink] due to priority: [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Five", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1301,7 +1301,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1309,8 +1309,8 @@ TEST_F(LedTest,
     }
     {
         // De-Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1318,7 +1318,7 @@ TEST_F(LedTest,
         EXPECT_EQ(false, result);
 
         // Need just the ledsDeAsssert populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1329,14 +1329,14 @@ TEST_F(LedTest,
         // [Ten] Moves to [On] since there is no prior [Blink]
         // [Three] remains [On] since it never changed state.
         // [Two] remains [On] since it did not go back
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Ten", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1355,8 +1355,8 @@ TEST_F(
                     twoGroupsWithMultipleComonLEDInDifferentStateDiffPriority);
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1364,7 +1364,7 @@ TEST_F(
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
@@ -1379,7 +1379,7 @@ TEST_F(
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1387,8 +1387,8 @@ TEST_F(
     }
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1399,7 +1399,7 @@ TEST_F(
         // [Two] gets to [ON] due to higher priority.
         // [Three] remains on since it never was in [Blink] before
         // [Ten] remains [Blink] due to priority: [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Five", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1409,7 +1409,7 @@ TEST_F(
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1417,8 +1417,8 @@ TEST_F(
     }
     {
         // De-Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1426,7 +1426,7 @@ TEST_F(
         EXPECT_EQ(false, result);
 
         // Need just the ledsDeAsssert populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"Five", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -1437,14 +1437,14 @@ TEST_F(
         // [Ten] remains [Blink] since it did not move to [On]
         // [Three] remains [On] since it never changed state.
         // [Two] moves to [Blink] since there is no prior [On]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1462,8 +1462,8 @@ TEST_F(LedTest,
                     twoGroupsWithMultipleComonLEDInDifferentStateDiffPriority);
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1471,7 +1471,7 @@ TEST_F(LedTest,
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
@@ -1485,7 +1485,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1493,8 +1493,8 @@ TEST_F(LedTest,
     }
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1505,7 +1505,7 @@ TEST_F(LedTest,
         // [Two] remains [ON] due to higher priority.
         // [Three] remains on since it never was in [Blink] before
         // [Ten] moves to [Blink] due to priority: [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1516,7 +1516,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1535,8 +1535,8 @@ TEST_F(
                     twoGroupsWithMultipleComonLEDInDifferentStateDiffPriority);
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1544,7 +1544,7 @@ TEST_F(
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
@@ -1558,7 +1558,7 @@ TEST_F(
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1566,8 +1566,8 @@ TEST_F(
     }
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1578,7 +1578,7 @@ TEST_F(
         // [Two] remains [ON] due to higher priority.
         // [Three] remains on since it never was in [Blink] before
         // [Ten] moves to [Blink] due to priority: [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1589,7 +1589,7 @@ TEST_F(
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1597,8 +1597,8 @@ TEST_F(
     }
     {
         // De-Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1607,7 +1607,7 @@ TEST_F(
 
         // Need just the ledsAssserted populated with these.
         // [Ten] remains [Blink] due to priority.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1618,14 +1618,14 @@ TEST_F(
         // [Two] remains [ON] due to higher priority.
         // [Three] remains [On] since it never was in [Blink] before
         // [Ten] moves to [On] due to priority: [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Ten", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1643,8 +1643,8 @@ TEST_F(LedTest,
                     twoGroupsWithMultipleComonLEDInDifferentStateDiffPriority);
     {
         // Assert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1652,7 +1652,7 @@ TEST_F(LedTest,
         EXPECT_EQ(true, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Three", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::Blink},
@@ -1666,7 +1666,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1674,8 +1674,8 @@ TEST_F(LedTest,
     }
     {
         // Assert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, true, ledsAssert,
@@ -1686,7 +1686,7 @@ TEST_F(LedTest,
         // [Two] remains [ON] due to higher priority.
         // [Three] remains on since it never was in [Blink] before
         // [Ten] moves to [Blink] due to priority: [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Four", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
@@ -1697,7 +1697,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsDeAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1705,8 +1705,8 @@ TEST_F(LedTest,
     }
     {
         // DeAssert Set-B
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1715,7 +1715,7 @@ TEST_F(LedTest,
 
         // Need just the ledsAssserted populated with these.
         // [Ten] remains [Blink] due to priority.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"Five", phosphor::led::Layout::On, 0, 0,
              phosphor::led::Layout::On},
             {"Six", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
@@ -1723,7 +1723,7 @@ TEST_F(LedTest,
         EXPECT_EQ(refDeAssert.size(), ledsDeAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1731,14 +1731,14 @@ TEST_F(LedTest,
 
         // Need just the ledsAssert populated with these.
         // [Two] will move to [Blink]
-        std::set<Layout::LedAction> refAssert = {
+        ActionSet refAssert = {
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
         };
         EXPECT_EQ(refAssert.size(), ledsAssert.size());
 
         // difference of refAssert and ledsAssert must be null.
-        Manager::group temp1{};
+        ActionSet temp1{};
         std::set_difference(ledsAssert.begin(), ledsAssert.end(),
                             refAssert.begin(), refAssert.end(),
                             std::inserter(temp1, temp1.begin()));
@@ -1746,8 +1746,8 @@ TEST_F(LedTest,
     }
     {
         // DeAssert Set-A
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsASet";
         auto result = manager.setGroupState(group, false, ledsAssert,
@@ -1755,7 +1755,7 @@ TEST_F(LedTest,
         EXPECT_EQ(false, result);
 
         // Need just the ledsAssserted populated with these.
-        std::set<Layout::LedAction> refDeAssert = {
+        ActionSet refDeAssert = {
             {"One", phosphor::led::Layout::On, 0, 0, phosphor::led::Layout::On},
             {"Two", phosphor::led::Layout::Blink, 0, 0,
              phosphor::led::Layout::On},
@@ -1770,7 +1770,7 @@ TEST_F(LedTest,
         EXPECT_EQ(0, ledsAssert.size());
 
         // difference of refDeAssert and ledsDeAssert must be null.
-        Manager::group temp{};
+        ActionSet temp{};
         std::set_difference(ledsDeAssert.begin(), ledsDeAssert.end(),
                             refDeAssert.begin(), refDeAssert.end(),
                             std::inserter(temp, temp.begin()));
@@ -1778,8 +1778,8 @@ TEST_F(LedTest,
     }
     {
         // DeAssert Set-B again and make sure we get all empty
-        Manager::group ledsAssert{};
-        Manager::group ledsDeAssert{};
+        ActionSet ledsAssert{};
+        ActionSet ledsDeAssert{};
 
         auto group = "/xyz/openbmc_project/ledmanager/groups/MultipleLedsBSet";
         auto result = manager.setGroupState(group, false, ledsAssert,


### PR DESCRIPTION
Use common types everywhere.
This commit removed LedAction and LedMap, instead
defined ActionSet and GroupMap and used it all the places.

Test:
Going on...

Change-Id: Id6473da0bc59b6a3a9f55b7f3cacb7f856dd89ae