### PR TITLE
meson_options.txt: Support for reading options from meson.options

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,29 @@
+option(
+    'tests', type : 'feature',
+    value: 'enabled',
+    description : 'Build tests'
+)
+
+option(
+    'use-json', type : 'feature',
+    value: 'enabled',
+    description : 'LEDs JSON filepath'
+)
+
+option(
+    'use-lamp-test', type : 'feature',
+    value: 'disabled',
+    description : 'LEDs lamp test configuration'
+)
+
+option(
+    'monitor-operational-status', type : 'feature',
+    value: 'disabled',
+    description : 'Enable OperationalStatus monitor'
+)
+
+option(
+    'monitor-sai-status', type : 'feature',
+    value: 'disabled',
+    description : 'Enable sai monitor'
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,0 @@
-option('tests', type : 'feature', description : 'Build tests')
-option('use-json', type : 'feature', description : 'LEDs JSON filepath', value: 'enabled')
-option('use-lamp-test', type : 'feature', description : 'LEDs lamp test configuration', value: 'disabled')
-option('monitor-operational-status', type : 'feature', description : 'Enable OperationalStatus monitor', value: 'disabled')
-option('monitor-sai-status', type : 'feature', description : 'Enable SAI monitor', value: 'disabled')


### PR DESCRIPTION
Support has been added for reading options from meson.options instead of meson_options.txt[1]. These are equivalent, but not using the .txt extension for a build file has a few advantages, chief among them many tools and text editors expect a file with the .txt extension to be plain text files, not build scripts.

[1] https://mesonbuild.com/Release-notes-for-1-1-0.html#support-for-reading-options-from-mesonoptions


Change-Id: Icf7286351b49c526d02327e3a2d72c40b5f9a960