### PR TITLE
build-tests: The allowed method is used by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -119,8 +119,7 @@ install_data(
 
 subdir('fault-monitor')
 
-build_tests = get_option('tests')
-if not build_tests.disabled()
+if get_option('tests').allowed()
   subdir('test')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,29 @@
-option('tests', type : 'feature', description : 'Build tests')
-option('use-json', type : 'feature', description : 'LEDs JSON filepath', value: 'disabled')
-option('use-lamp-test', type : 'feature', description : 'LEDs lamp test configuration', value: 'disabled')
-option('monitor-operational-status', type : 'feature', description : 'Enable OperationalStatus monitor', value: 'disabled')
-option('monitor-sai-status', type : 'feature', description : 'Enable SAI monitor', value: 'disabled')
+option(
+    'tests', type : 'feature',
+    value: 'enabled',
+    description : 'Build tests'
+)
+
+option(
+    'use-json', type : 'feature',
+    value: 'enabled',
+    description : 'LEDs JSON filepath'
+)
+
+option(
+    'use-lamp-test', type : 'feature',
+    value: 'disabled',
+    description : 'LEDs lamp test configuration'
+)
+
+option(
+    'monitor-operational-status', type : 'feature',
+    value: 'disabled',
+    description : 'Enable OperationalStatus monitor'
+)
+
+option(
+    'monitor-sai-status', type : 'feature',
+    value: 'disabled',
+    description : 'Enable sai monitor'
+)


### PR DESCRIPTION
The allowed method returns true when the feature is set to `enabled` or `auto`.
The allowed method returns false when the feature is set to `disabled`.
So we prefer to use the `allowed` method instead of `enabled`.


Change-Id: I3cc28241cd9ef0d907aa73409a63a4470a628e70