### PR TITLE
Fix sdbus++-gen-meson version warning

### DIFF
--- a/gen/README
+++ b/gen/README
@@ -1,0 +1,2 @@
+This directory contains generated meson.build files from sdbus++-gen-meson.
+Do not edit them by hand.

--- a/gen/meson.build
+++ b/gen/meson.build
@@ -4,10 +4,10 @@ sdbuspp_gen_meson_ver = run_command(
     '--version',
 ).stdout().strip().split('\n')[0]
 
-if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 1'
+if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 3'
     warning('Generated meson files from wrong version of sdbus++-gen-meson.')
     warning(
-        'Expected "sdbus++-gen-meson version 1", got:',
+        'Expected "sdbus++-gen-meson version 3", got:',
         sdbuspp_gen_meson_ver
     )
 endif


### PR DESCRIPTION
WARNING: Generated meson files from wrong version of sdbus++-gen-meson.
WARNING: Expected "sdbus++-gen-meson version 1",
got: sdbus++-gen-meson version 3

Add the regenerate-meson file to automatically update meson.build.


Change-Id: If1ce533bc0f6bafbe75d05595f9d36f5f652bd45