### PR TITLE
meson: set use-json as default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('tests', type : 'feature', description : 'Build tests')
-option('use-json', type : 'feature', description : 'LEDs JSON filepath', value: 'disabled')
+option('use-json', type : 'feature', description : 'LEDs JSON filepath', value: 'enabled')
 option('use-lamp-test', type : 'feature', description : 'LEDs lamp test configuration', value: 'disabled')
 option('monitor-operational-status', type : 'feature', description : 'Enable OperationalStatus monitor', value: 'disabled')
 option('monitor-sai-status', type : 'feature', description : 'Enable SAI monitor', value: 'disabled')


### PR DESCRIPTION
In order to get broader testing in CI, enable use-json by default. This is the preferred system configuration direction.


Change-Id: Ice51af8a61443f30e42741fdd90f935cd0aa8cbf