### PR TITLE
meson: simplify dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,28 +28,10 @@ conf_data.set('MONITOR_OPERATIONAL_STATUS', get_option('monitor-operational-stat
 conf_data.set('IBM_SAI', get_option('monitor-sai-status').enabled())
 
 sdbusplus_dep = dependency('sdbusplus')
+sdeventplus_dep = dependency('sdeventplus')
+phosphor_dbus_interfaces_dep = dependency('phosphor-dbus-interfaces')
+phosphor_logging_dep = dependency('phosphor-logging')
 
-sdeventplus_dep = dependency(
-    'sdeventplus',
-    fallback: [
-        'sdeventplus',
-        'sdeventplus_dep'
-    ],
-)
-phosphor_logging_dep = dependency(
-    'phosphor-logging',
-    fallback: [
-        'phosphor-logging',
-        'phosphor_logging_dep'
-    ],
-)
-phosphor_dbus_interfaces_dep = dependency(
-    'phosphor-dbus-interfaces',
-    fallback: [
-        'phosphor-dbus-interfaces',
-        'phosphor_dbus_interfaces_dep'
-    ],
-)
 prog_python = find_program('python3', required: true)
 realpath_prog = find_program('realpath')
 
@@ -69,10 +51,7 @@ endif
 if cpp.has_header('CLI/CLI.hpp')
     CLI11_dep = declare_dependency()
 else
-    CLI11_dep = dependency(
-        'CLI11',
-        fallback: [ 'CLI11', 'CLI11_dep' ],
-    )
+    CLI11_dep = dependency('CLI11')
 endif
 
 

--- a/subprojects/CLI11.wrap
+++ b/subprojects/CLI11.wrap
@@ -1,3 +1,6 @@
 [wrap-git]
 url = https://github.com/CLIUtils/CLI11.git
 revision = HEAD
+
+[provide]
+CLI11 = CLI11_dep

--- a/subprojects/phosphor-dbus-interfaces.wrap
+++ b/subprojects/phosphor-dbus-interfaces.wrap
@@ -1,3 +1,6 @@
 [wrap-git]
 url = https://github.com/openbmc/phosphor-dbus-interfaces.git
 revision = HEAD
+
+[provide]
+phosphor-dbus-interfaces = phosphor_dbus_interfaces_dep

--- a/subprojects/phosphor-logging.wrap
+++ b/subprojects/phosphor-logging.wrap
@@ -1,3 +1,6 @@
 [wrap-git]
 url = https://github.com/openbmc/phosphor-logging.git
 revision = HEAD
+
+[provide]
+phosphor-logging = phosphor_logging_dep

--- a/subprojects/sdeventplus.wrap
+++ b/subprojects/sdeventplus.wrap
@@ -1,3 +1,6 @@
 [wrap-git]
 url = https://github.com/openbmc/sdeventplus.git
 revision = HEAD
+
+[provide]
+sdeventplus = sdeventplus_dep


### PR DESCRIPTION
Leverage wrapfile `[provide]` directives to simplify the dependency searching in the meson.build.


Change-Id: I4b8aac501a91075b092552daf6735037f6968d7e