### PR TITLE
build: upgrade to C++23

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,12 @@
 project(
     'phosphor-ledmanager', 'cpp',
     version : '1.0.0',
-    meson_version: '>=0.58.0',
+    meson_version: '>=1.1.1',
     default_options: [
         'warning_level=3',
         'werror=true',
-        'cpp_std=c++20',
-        'buildtype=debugoptimized'
+        'cpp_std=c++23',
+        'buildtype=debugoptimized',
     ]
 )
 


### PR DESCRIPTION
Meson 1.1.1 and GCC-13 both support C++23 and a sufficient portion of the standard has been implemented.  Upgrade the build to leverage it.

Change-Id: Ie0245d2667cfb2917e1af6d57f82a1d20fef8d60