### PR TITLE
led tool: toggle fault LEDs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,7 @@ install_data(
 )
 
 subdir('fault-monitor')
+subdir('tools')
 
 build_tests = get_option('tests')
 if not build_tests.disabled()

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,0 +1,38 @@
+#include "toggle-fault-leds.hpp"
+
+#include <CLI/CLI.hpp>
+
+int main(int argc, char** argv)
+{
+    CLI::App app{"led-tool - A tool to perform opeartion(s) over LEDs."};
+
+    bool isFunctional = true;
+    auto functional = app.add_option(
+        "-f, --functional", isFunctional,
+        "True/False depending upon the functional status of FRU.");
+
+    auto toggleFaultLed =
+        app.add_flag(
+               "-t, --toggleFaultLeds",
+               "Toggles asserted property for fault LEDs according to the "
+               "functional status passed. Also updates functional property "
+               "of the FRUs hosted under PIM accordingly.")
+            ->needs(functional);
+
+    CLI11_PARSE(app, argc, argv);
+
+    try
+    {
+        if (*toggleFaultLed)
+        {
+            toggleFaultLeds(isFunctional);
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cout << "Led tool failed with exception: " << ex.what()
+                  << std::endl;
+    }
+
+    return 0;
+}

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,12 @@
+tool_sources = [
+    'main.cpp',
+]
+configuration_inc = include_directories('.')
+
+led_tools_exe = executable(
+                'led-tool',
+                tool_sources,
+                dependencies: [sdbusplus_dep],
+                include_directories : configuration_inc,
+                install: true,
+                )

--- a/tools/toggle-fault-leds.hpp
+++ b/tools/toggle-fault-leds.hpp
@@ -1,0 +1,102 @@
+#pragma once
+#include "utility.hpp"
+
+/**
+ * @brief API to toggle fault LEDs according to the given functional status.
+ *
+ * The API sets "Functional" property hosted by operational status interface for
+ * all the FRUs under root path "/xyz/openbmc_project/inventory". It also
+ * fetches associated LEDs object path for FRUs, hosted under LED manager and
+ * sets asserted value accordingly.
+ *
+ * The API skips some specific FRUs, although they host operational status based
+ * on following criteria.
+ * - Can be a guarded FRU.
+ * - Operational status of the FRU is handled by some other module.
+ *
+ * @param[in] isFunctional - States if the FRUs are functional or not.
+ */
+void toggleFaultLeds(const bool isFunctional)
+{
+    std::cout << "Trigger toggling of fault LEDs with value: " << isFunctional
+              << std::endl;
+
+    std::vector<std::string> skipOperationalStatusForFRUs{
+        "core", "powersupply", "unit", "connector", "chassis1"};
+
+    std::vector<std::string> frusWithoutLED{
+        "pcie_card", "usb",    "drive",       "ethernet",  "fan0_",
+        "fan1_",     "fan2_",  "fan3_",       "fan4_",     "fan5_",
+        "rdx",       "cables", "displayport", "pcieslot12"};
+
+    if (utility::isChassisOn())
+    {
+        std::cout << "Abort toggling fault LED. Chassis is in power on state."
+                  << std::endl;
+
+        return;
+    }
+
+    std::vector<std::string> interfaces{
+        "xyz.openbmc_project.State.Decorator.OperationalStatus"};
+
+    utility::MapperResponse subTree = utility::getObjectSubtreeForInterfaces(
+        "/xyz/openbmc_project/inventory", 0, interfaces);
+
+    if (subTree.size() == 0)
+    {
+        std::cout
+            << "No sub tree found for OperationalStatus interfaces. Exiting."
+            << std::endl;
+
+        return;
+    }
+
+    for (const auto& [objectPath, serviceInterfaceMap] : subTree)
+    {
+        if (std::any_of(skipOperationalStatusForFRUs.cbegin(),
+                        skipOperationalStatusForFRUs.cend(),
+                        [&objectPath](const std::string& aFru) {
+            return objectPath.find(aFru) != std::string::npos;
+        }))
+        {
+            // Skip setting operational status for these paths.
+            continue;
+        }
+
+        utility::setProperty<bool>(
+            "xyz.openbmc_project.Inventory.Manager", objectPath,
+            "xyz.openbmc_project.State.Decorator.OperationalStatus",
+            "Functional", isFunctional);
+
+        if (std::any_of(frusWithoutLED.cbegin(), frusWithoutLED.cend(),
+                        [&objectPath](const std::string& aFru) {
+            return objectPath.find(aFru) != std::string::npos;
+        }))
+        {
+            // Skipping path with no LEDs.
+            continue;
+        }
+
+        auto retVal =
+            utility::getProperty<std::variant<std::vector<std::string>>>(
+                "xyz.openbmc_project.ObjectMapper",
+                objectPath + "/fault_identifying",
+                "xyz.openbmc_project.Association", "endpoints");
+
+        if (auto endpoints = std::get_if<std::vector<std::string>>(&retVal))
+        {
+            for (const auto& path : *endpoints)
+            {
+                // Asserted is inverse of functional status.
+                utility::setProperty<bool>(
+                    "xyz.openbmc_project.LED.GroupManager", path,
+                    "xyz.openbmc_project.Led.Group", "Asserted", !isFunctional);
+            }
+        }
+        else
+        {
+            std::cout << "No endpoints for path: " << objectPath << std::endl;
+        }
+    }
+}

--- a/tools/utility.hpp
+++ b/tools/utility.hpp
@@ -1,0 +1,146 @@
+#pragma once
+#include <sdbusplus/server.hpp>
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace utility
+{
+
+/**
+ * @brief An API to make GetSubTree mapper call.
+ *
+ * @return MapperResponse - Response from the API.
+ */
+// map<inventory_path, map<service_name, vector<interface>>>
+using MapperResponse =
+    std::map<std::string, std::map<std::string, std::vector<std::string>>>;
+
+MapperResponse
+    getObjectSubtreeForInterfaces(const std::string& root, const int32_t depth,
+                                  const std::vector<std::string>& interfaces)
+{
+    auto bus = sdbusplus::bus::new_default();
+    auto mapperCall = bus.new_method_call("xyz.openbmc_project.ObjectMapper",
+                                          "/xyz/openbmc_project/object_mapper",
+                                          "xyz.openbmc_project.ObjectMapper",
+                                          "GetSubTree");
+    mapperCall.append(root);
+    mapperCall.append(depth);
+    mapperCall.append(interfaces);
+
+    MapperResponse result = {};
+
+    try
+    {
+        auto response = bus.call(mapperCall);
+
+        response.read(result);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::cout << "GetSubtree mapper call failed with exception: "
+                  << e.what() << std::endl;
+    }
+    return result;
+}
+
+/**
+ * @brief Templated API to set D-Bus property.
+ *
+ * @param[in] serviceName - D-Bus service name hosting the object path.
+ * @param[in] objectPath - D-Bus object path hosting the interface.
+ * @param[in] interface - D-Bus interface hosting the property.
+ * @param[in] property - D-Bus property to be set.
+ * @param[in] value - Value to be set.
+ */
+template <typename T>
+void setProperty(const std::string& serviceName, const std::string& objectPath,
+                 const std::string& interface, const std::string& property,
+                 const std::variant<T>& value)
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method =
+            bus.new_method_call(serviceName.c_str(), objectPath.c_str(),
+                                "org.freedesktop.DBus.Properties", "Set");
+
+        method.append(interface);
+        method.append(property);
+        method.append(value);
+        bus.call(method);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cout << "Set property: " << property
+                  << " failed for path: " << objectPath
+                  << " with error: " << e.what() << std::endl;
+    }
+}
+
+/**
+ * @brief Templated API to get D-Bus property.
+ *
+ * @param[in] serviceName - D-Bus service name hosting the object path.
+ * @param[in] objectPath - D-Bus object path hosting the interface.
+ * @param[in] interface - D-Bus interface hosting the property.
+ * @param[in] property - D-Bus property whose value is to be fetched.
+ * @return Value of the property.
+ */
+template <typename T>
+T getProperty(const std::string& serviceName, const std::string& objectPath,
+              const std::string& interface, const std::string& property)
+{
+    auto bus = sdbusplus::bus::new_default();
+    auto mapperCall =
+        bus.new_method_call(serviceName.c_str(), objectPath.c_str(),
+                            "org.freedesktop.DBus.Properties", "Get");
+    mapperCall.append(interface);
+    mapperCall.append(property);
+
+    T result = {};
+
+    try
+    {
+        auto response = bus.call(mapperCall);
+
+        response.read(result);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::cout << "Get property: " << property
+                  << " failed for path: " << objectPath
+                  << " with error: " << e.what() << std::endl;
+    }
+
+    return result;
+}
+
+/**
+ * @brief An API to check chassis power state.
+ *
+ * @return bool - True when chassis power state is on, false otherwise.
+ */
+bool isChassisOn()
+{
+    auto retVal = getProperty<std::variant<std::string>>(
+        "xyz.openbmc_project.State.Chassis0",
+        "/xyz/openbmc_project/state/chassis0",
+        "xyz.openbmc_project.State.Chassis", "CurrentPowerState");
+
+    if (auto powerSate = std::get_if<std::string>(&retVal))
+    {
+        if (*powerSate == "xyz.openbmc_project.State.Chassis.PowerState.On")
+        {
+            return true;
+        }
+    }
+
+    // In any error condition assuming chassis is off.
+    return false;
+}
+} // namespace utility


### PR DESCRIPTION
The commit implements base framework for led tool with an option to toggle fault LEDs based on the functional status of the FRU.

The tool will be auto triggered with different optiosn on BMC boot and system power on, driven via system-d service files.

Tool can be used via command line as well.