### PR TITLE
Rmove triggerring of critical association

### DIFF
--- a/tools/service/obmc-clear-all-fault-leds-and-remove-crit-association@.service
+++ b/tools/service/obmc-clear-all-fault-leds-and-remove-crit-association@.service
@@ -10,5 +10,4 @@ ConditionPathExists=!/run/openbmc/chassis@0-on
 Type=oneshot
 Restart=no
 ExecStart=/usr/bin/env led-tool --functional %i --toggleFaultLeds
-ExecStart=/usr/bin/remove-association
 SyslogIdentifier=obmc-clear-all-fault-leds-and-remove-crit-association


### PR DESCRIPTION
Currently the support for exe is not availlable in the build. Removing it till the support is made available.