### PR TITLE
Tool option to set LED default state

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,4 +1,5 @@
 #include "set-guarded-fru-leds.hpp"
+#include "set-leds-default-state.hpp"
 #include "toggle-fault-leds.hpp"
 
 #include <CLI/CLI.hpp>
@@ -23,6 +24,10 @@ int main(int argc, char** argv)
     auto setGuardedFruLeds = app.add_flag("-s, --setGuardedFruLeds",
                                           "Set LEDs for guarded FRUs.");
 
+    auto defaultLedsSate = app.add_flag("-d, --defaultLedsState",
+                                        "Sets power, enclosure fault, SAI and "
+                                        "enclosure identify to default state.");
+
     CLI11_PARSE(app, argc, argv);
 
     try
@@ -35,6 +40,11 @@ int main(int argc, char** argv)
         if (*setGuardedFruLeds)
         {
             setLEDForGuardedFru();
+        }
+
+        if (*defaultLedsSate)
+        {
+            setLedsDefaultState();
         }
     }
     catch (const std::exception& ex)

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -4,7 +4,8 @@ tool_sources = [
 configuration_inc = include_directories('.')
 
 services = ['service/obmc-clear-all-fault-leds-and-remove-crit-association@.service',
-            'service/obmc-set-guarded-frus-leds@.service']
+            'service/obmc-set-guarded-frus-leds@.service',
+            'service/obmc-set-leds-default-state@.service']
             
 systemd_system_unit_dir = dependency('systemd').get_variable(
         'systemdsystemunitdir')

--- a/tools/service/obmc-set-leds-default-state@.service
+++ b/tools/service/obmc-set-leds-default-state@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Initialize LEDs to default state
+After=xyz.openbmc_project.led.controller@sys-class-leds-pca955x:front-sys-pwron0.service
+After=xyz.openbmc_project.LED.GroupManager.service
+After=phosphor-reset-chassis-running@0.service
+ConditionPathExists=!/run/openbmc/chassis@0-on
+
+[Service]
+Type=oneshot
+Restart=no
+ExecStart=/usr/bin/env led-tool --defaultLedsState
+SyslogIdentifier=obmc-set-leds-to-default-state

--- a/tools/set-leds-default-state.hpp
+++ b/tools/set-leds-default-state.hpp
@@ -1,0 +1,59 @@
+#pragma once
+#include "utility.hpp"
+
+/**
+ * @brief API to set asserted property to false.
+ *
+ * @param[in] ObjectPath - LEDs D-Bus path.
+ */
+void setAssertedToFalse(const std::string ObjectPath)
+{
+    utility::setProperty<bool>("xyz.openbmc_project.LED.GroupManager",
+                               ObjectPath, "xyz.openbmc_project.Led.Group",
+                               "Asserted", false);
+}
+
+/**
+ * @brief Sets default state for some of the LEDs.
+ *
+ * The asserted property for SAI and enclosure fault LED needs to be reset at
+ * every reboot so that in case of any new PELs that require to trigger SAI, the
+ * property can be set and a signal can be emitted for physical LEDs to behave
+ * accordingly. Enclosure identify - need not be persisted.
+ * Explicitly Asserted being set as there is no operational status associated
+ * these LEDs.
+ */
+void setLedsDefaultState()
+{
+    std::cout << "Trigger set default state for LEDs." << std::endl;
+
+    if (utility::isChassisOn())
+    {
+        std::cout
+            << "Abort setting LEDs to default as chassis is in power on state."
+            << std::endl;
+
+        return;
+    }
+
+    // set default state for power button.
+    utility::setProperty<std::string>(
+        "xyz.openbmc_project.LED.Controller.pca955x_front_sys_pwron0",
+        "/xyz/openbmc_project/led/physical/pca955x_front_sys_pwron0",
+        "xyz.openbmc_project.Led.Physical", "State",
+        "xyz.openbmc_project.Led.Physical.Action.Blink");
+
+    // set default state for enclosure fault.
+    setAssertedToFalse("/xyz/openbmc_project/led/groups/enclosure_fault");
+
+    // set default state for Platform SAI.
+    setAssertedToFalse(
+        "/xyz/openbmc_project/led/groups/platform_system_attention_indicator");
+
+    // set default state for Partition SAI.
+    setAssertedToFalse(
+        "/xyz/openbmc_project/led/groups/partition_system_attention_indicator");
+
+    // set default state for enclosure identify.
+    setAssertedToFalse("/xyz/openbmc_project/led/groups/enclosure_identify");
+}


### PR DESCRIPTION
The commit adds option in the tool to set all the LEDs to their default state.
The service file has been added to trigger the same at every boot via recipe files.