### PR TITLE
CLear PSU fault LEDs

### DIFF
--- a/tools/clear-psu-fault-leds.hpp
+++ b/tools/clear-psu-fault-leds.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "utility.hpp"
+
+#include <unistd.h>
+
+/**
+ * @brief API to clear PSU fault LEDs.
+ *
+ * The function, sets operational status of powersupply FRU to true as well as
+ * corresponding asserted property of fault led associated with that FRU to
+ * false.
+ *
+ * Note: The retry mechanishm is to wait for LED service to come up without
+ * which the call to fetch endpoints would fail.
+ * Explicit dependency for LED is not added in service as it will delay the
+ * execution further and clearing of PSU LED should happen asap.
+ */
+void clearPsuFaultLeds()
+{
+    // sufficiently large number within which the LED service should come up.
+    static constexpr auto MAX_RETRY = 120;
+
+    if (utility::isChassisOn())
+    {
+        std::cout
+            << "Abort clearing PSU fault LED. Chassis is in power on state."
+            << std::endl;
+
+        return;
+    }
+
+    std::vector<std::string> interfaces{
+        "xyz.openbmc_project.Inventory.Item.PowerSupply"};
+
+    utility::MapperResponse subTree = utility::getObjectSubtreeForInterfaces(
+        "/xyz/openbmc_project/inventory", 0, interfaces);
+
+    if (subTree.size() == 0)
+    {
+        std::cerr << "No sub tree found for power supply interfaces. Exiting."
+                  << std::endl;
+
+        return;
+    }
+
+    for (const auto& [objectPath, serviceInterfaceMap] : subTree)
+    {
+        auto retryCounter = MAX_RETRY;
+
+        while (retryCounter != 0)
+        {
+            utility::ListOfObjectPaths objPathList =
+                utility::GetAssociatedSubTreePaths(
+                    std::string(objectPath + "/fault_identifying"),
+                    std::string("/xyz/openbmc_project/led/groups"), 0,
+                    std::vector<std::string>{});
+
+            // If path list is empty, implies LED service is not yet up. We
+            // need to wait for the service.
+            if (objPathList.size() == 0)
+            {
+                retryCounter--;
+                sleep(1);
+                continue;
+            }
+            break;
+        }
+
+        // timer exhausted. Flag the error.
+        if (retryCounter == 0)
+        {
+            std::cerr << "Could not find associated object path for: "
+                      << objectPath << " Exiting." << std::endl;
+            return;
+        }
+
+        utility::setProperty<bool>(
+            "xyz.openbmc_project.Inventory.Manager", objectPath,
+            "xyz.openbmc_project.State.Decorator.OperationalStatus",
+            "Functional", true);
+
+        auto retVal =
+            utility::getProperty<std::variant<std::vector<std::string>>>(
+                "xyz.openbmc_project.ObjectMapper",
+                objectPath + "/fault_identifying",
+                "xyz.openbmc_project.Association", "endpoints");
+
+        if (auto endpoints = std::get_if<std::vector<std::string>>(&retVal))
+        {
+            for (const auto& path : *endpoints)
+            {
+                // Asserted is inverse of functional status.
+                utility::setProperty<bool>(
+                    "xyz.openbmc_project.LED.GroupManager", path,
+                    "xyz.openbmc_project.Led.Group", "Asserted", false);
+            }
+
+            std::cout << "Setting endpoint for object path: " << objectPath
+                      << " completed in " << (MAX_RETRY - retryCounter)
+                      << " seconds." << std::endl;
+        }
+        else
+        {
+            std::cout << "No endpoints for path: " << objectPath << std::endl;
+        }
+    }
+}

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,3 +1,4 @@
+#include "clear-psu-fault-leds.hpp"
 #include "set-guarded-fru-leds.hpp"
 #include "set-leds-default-state.hpp"
 #include "toggle-fault-leds.hpp"
@@ -28,6 +29,9 @@ int main(int argc, char** argv)
                                         "Sets power, enclosure fault, SAI and "
                                         "enclosure identify to default state.");
 
+    auto clearPsuFaultLed = app.add_flag("-c, --clearPsuFaultLed",
+                                         "Clears PSU fault LEDs.");
+
     CLI11_PARSE(app, argc, argv);
 
     try
@@ -45,6 +49,11 @@ int main(int argc, char** argv)
         if (*defaultLedsSate)
         {
             setLedsDefaultState();
+        }
+
+        if (*clearPsuFaultLed)
+        {
+            clearPsuFaultLeds();
         }
     }
     catch (const std::exception& ex)

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -5,7 +5,8 @@ configuration_inc = include_directories('.')
 
 services = ['service/obmc-clear-all-fault-leds-and-remove-crit-association@.service',
             'service/obmc-set-guarded-frus-leds@.service',
-            'service/obmc-set-leds-default-state@.service']
+            'service/obmc-set-leds-default-state@.service',
+            'service/obmc-clear-psu-fault-leds@.service']
             
 systemd_system_unit_dir = dependency('systemd').get_variable(
         'systemdsystemunitdir')

--- a/tools/service/obmc-clear-psu-fault-leds@.service
+++ b/tools/service/obmc-clear-psu-fault-leds@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Clears PSU fault LEDs on BMC
+After=obmc-chassis-powerreset@0.target
+Wants=obmc-power-reset-on@0.target
+After=obmc-power-reset-on@0.target
+Before=op-power-start@0.service
+ConditionPathExists=!/run/openbmc/chassis@0-on
+Before=phosphor-psu-monitor.service
+
+[Service]
+Type=oneshot
+Restart=no
+ExecStart=/usr/bin/env led-tool --clearPsuFaultLed
+SyslogIdentifier=obmc-clear-psu-fault-leds


### PR DESCRIPTION
The commit provides an option to clear fault LEDs for PSU. It will also be triggered via service file on every BMC reboot.

The functionality is required as PSU handles its own fault LEDs and hence before PSU comes up any previous fault, logged in previous boot should be cleared.