### PR TITLE
LED:Skip clearing external chassis's PSU fault led

### DIFF
--- a/manager/manager.hpp
+++ b/manager/manager.hpp
@@ -83,8 +83,8 @@ class Manager
     Manager(
         sdbusplus::bus_t& bus, const GroupMap& ledLayout,
         const sdeventplus::Event& event = sdeventplus::Event::get_default()) :
-        ledMap(ledLayout),
-        bus(bus), timer(event, [this](auto&) { driveLedsHandler(); })
+        ledMap(ledLayout), bus(bus),
+        timer(event, [this](auto&) { driveLedsHandler(); })
     {
         // Nothing here
     }

--- a/tools/clear-psu-fault-leds.hpp
+++ b/tools/clear-psu-fault-leds.hpp
@@ -46,6 +46,15 @@ void clearPsuFaultLeds()
 
     for (const auto& [objectPath, serviceInterfaceMap] : subTree)
     {
+        // Find the service which hosts the current objectPath.
+        if (!serviceInterfaceMap.contains(
+                "xyz.openbmc_project.Inventory.Manager"))
+        {
+            // If this object path is not hosted by inventory manager service,
+            // do not take any action.
+            continue;
+        }
+
         auto retryCounter = MAX_RETRY;
 
         while (retryCounter != 0)


### PR DESCRIPTION
This commit skips clearning the fault led of PSUs whose D-bus objects are not hosted by xyz.openbmc_project.Inventory.Manager service.
This is required in case when PLDM service hosts the PSU's of external chassis like MEX/Splitter/Nimitz, led-tool which runs on BMC should not attempt to clear it's fault led.

Test:
Tested that led-tool doesn't add a wait time to clear fault PSU leds of MEX/Splitter/Nimitz chassis.

Test log:
Feb 04 10:33:34 mexbmc systemd[1]: Starting Clears PSU fault LEDs on BMC... Feb 04 10:33:34 mexbmc obmc-clear-psu-fault-leds[1923]: Setting endpoint for object path: /xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0 completed in 0 seconds. Feb 04 10:33:34 mexbmc obmc-clear-psu-fault-leds[1923]: Setting endpoint for object path: /xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1 completed in 0 seconds. Feb 04 10:33:34 mexbmc systemd[1]: Starting Check chassis power status... Feb 04 10:33:35 mexbmc phosphor-chassis-state-manager[729]: Change to Chassis Power State: xyz.openbmc_project.State.Chassis.PowerState.TransitioningToOn Feb 04 10:33:35 mexbmc systemd[1]: obmc-clear-psu-fault-leds@0.service: Deactivated successfully. Feb 04 10:33:35 mexbmc systemd[1]: Finished Clears PSU fault LEDs on BMC. Feb 04 10:33:40 mexbmc phosphor-chassis-state-manager[729]: Change to Chassis Power State: xyz.openbmc_project.State.Chassis.PowerState.On

Change-Id: Ib58356550e8f431410fac66586f9ed7ee9965429