### PR TITLE
Call PIM to update the functional property

### DIFF
--- a/ibm-sai.cpp
+++ b/ibm-sai.cpp
@@ -54,10 +54,10 @@ void setOperationalStatus(const std::string& path, bool value)
         try
         {
             utils::PropertyValue functionalValue{value};
-            utils::DBusHandler().setProperty(
-                fruInstancePath,
-                "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "Functional", functionalValue);
+            utils::DBusHandler().notifyPIM(
+                {{fruInstancePath,
+                  {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    {{"Functional", functionalValue}}}}}});
         }
         catch (const sdbusplus::exception::SdBusError& e)
         {

--- a/tools/clear-psu-fault-leds.hpp
+++ b/tools/clear-psu-fault-leds.hpp
@@ -84,10 +84,10 @@ void clearPsuFaultLeds()
             return;
         }
 
-        utility::setProperty<bool>(
-            "xyz.openbmc_project.Inventory.Manager", objectPath,
-            "xyz.openbmc_project.State.Decorator.OperationalStatus",
-            "Functional", true);
+        utility::notifyPIM(
+            {{objectPath,
+              {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                {{"Functional", true}}}}}});
 
         auto retVal =
             utility::getProperty<std::variant<std::vector<std::string>>>(

--- a/tools/set-guarded-fru-leds.hpp
+++ b/tools/set-guarded-fru-leds.hpp
@@ -38,6 +38,8 @@ void setLEDForGuardedFru()
         return;
     }
 
+    utility::ObjectMap objectMap;
+
     for (const auto& [objectPath, serviceInterfceMap] : subTree)
     {
         auto retVal = utility::getProperty<std::variant<
@@ -55,10 +57,13 @@ void setLEDForGuardedFru()
 
                 if (guardedPath.find("dimm") != std::string::npos)
                 {
-                    utility::setProperty<bool>(
-                        "xyz.openbmc_project.Inventory.Manager", guardedPath,
-                        "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                        "Functional", false);
+                    objectMap.emplace(
+                        guardedPath,
+                        std::map<std::string,
+                                 std::map<std::string, std::variant<bool>>>{
+                            {"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                             {{"Functional", false}}}});
+
                     continue;
                 }
 
@@ -68,14 +73,17 @@ void setLEDForGuardedFru()
                     // PIM. Which is not tied to LEDs.
                     if (guardedPath.find("unit") != std::string::npos)
                     {
-                        utility::setProperty<bool>(
-                            "xyz.openbmc_project.Inventory.Manager",
+                        objectMap.emplace(
                             guardedPath,
-                            "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                            "Functional", false);
+                            std::map<std::string,
+                                     std::map<std::string, std::variant<bool>>>{
+                                {"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                                 {{"Functional", false}}}});
                     }
                 }
             }
         }
     }
+
+    utility::notifyPIM(std::move(objectMap));
 }

--- a/tools/toggle-fault-leds.hpp
+++ b/tools/toggle-fault-leds.hpp
@@ -64,10 +64,10 @@ void toggleFaultLeds(const bool isFunctional)
             continue;
         }
 
-        utility::setProperty<bool>(
-            "xyz.openbmc_project.Inventory.Manager", objectPath,
-            "xyz.openbmc_project.State.Decorator.OperationalStatus",
-            "Functional", isFunctional);
+        utility::notifyPIM(
+            {{objectPath,
+              {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                {{"Functional", isFunctional}}}}}});
 
         if (std::any_of(frusWithoutLED.cbegin(), frusWithoutLED.cend(),
                         [&objectPath](const std::string& aFru) {

--- a/tools/utility.hpp
+++ b/tools/utility.hpp
@@ -185,4 +185,47 @@ bool isChassisOn()
     // In any error condition assuming chassis is off.
     return false;
 }
+
+using ObjectMap =
+    std::map<sdbusplus::message::object_path,
+             std::map<std::string, std::map<std::string, std::variant<bool>>>>;
+
+/**
+ * @brief An API to call PIM
+ *
+ * This API calls notify method of PIM to update the property value.
+ *
+ * @param[in] objectMap - Map of object path, interface, property and its value.
+ */
+void notifyPIM(ObjectMap&& objectMap)
+{
+    try
+    {
+        for (const auto& objectKeyValue : objectMap)
+        {
+            auto objectPath = objectMap.extract(objectKeyValue.first);
+
+            if (objectPath.key().str.find("/xyz/openbmc_project/inventory",
+                                          0) != std::string::npos)
+            {
+                objectPath.key() = objectPath.key().str.replace(
+                    0, strlen("/xyz/openbmc_project/inventory"), "");
+                objectMap.insert(std::move(objectPath));
+            }
+        }
+
+        auto bus = sdbusplus::bus::new_default();
+        auto pimMsg = bus.new_method_call(
+            "xyz.openbmc_project.Inventory.Manager",
+            "/xyz/openbmc_project/inventory",
+            "xyz.openbmc_project.Inventory.Manager", "Notify");
+        pimMsg.append(std::move(objectMap));
+        bus.call(pimMsg);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cerr << "Notify PIM to update property value failed with error: "
+                  << e.what() << std::endl;
+    }
+}
 } // namespace utility

--- a/utils.cpp
+++ b/utils.cpp
@@ -125,6 +125,30 @@ const std::vector<std::string>
     return paths;
 }
 
+void DBusHandler::notifyPIM(ObjectMap&& objectMap)
+{
+    for (const auto& objectKeyValue : objectMap)
+    {
+        auto objectPath = objectMap.extract(objectKeyValue.first);
+
+        if (objectPath.key().str.find("/xyz/openbmc_project/inventory", 0) !=
+            std::string::npos)
+        {
+            objectPath.key() = objectPath.key().str.replace(
+                0, strlen("/xyz/openbmc_project/inventory"), "");
+            objectMap.insert(std::move(objectPath));
+        }
+    }
+
+    auto bus = sdbusplus::bus::new_default();
+    auto pimMsg = bus.new_method_call("xyz.openbmc_project.Inventory.Manager",
+                                      "/xyz/openbmc_project/inventory",
+                                      "xyz.openbmc_project.Inventory.Manager",
+                                      "Notify");
+    pimMsg.append(std::move(objectMap));
+    bus.call(pimMsg);
+}
+
 } // namespace utils
 } // namespace led
 } // namespace phosphor

--- a/utils.hpp
+++ b/utils.hpp
@@ -32,6 +32,10 @@ using DbusProperty = std::string;
 // The Map to constructs all properties values of the interface
 using PropertyMap = std::unordered_map<DbusProperty, PropertyValue>;
 
+using ObjectMap =
+    std::map<sdbusplus::message::object_path,
+             std::map<std::string, std::map<std::string, std::variant<bool>>>>;
+
 /**
  *  @class DBusHandler
  *
@@ -111,6 +115,18 @@ class DBusHandler
     const std::vector<std::string>
         getSubTreePaths(const std::string& objectPath,
                         const std::string& interface);
+
+    /**
+     * @brief An API to call PIM
+     *
+     * This API calls notify method of PIM to update the property value.
+     *
+     * @param[in] objectMap - Map of object path, interface, property and its
+     * value.
+     *
+     * @throw sdbusplus::exception_t when it fails
+     */
+    void notifyPIM(ObjectMap&& objectMap);
 };
 
 } // namespace utils


### PR DESCRIPTION
During power-on, clear-all-fault-leds service clears all the fault leds by setting the functional property of the corresponding led FRU to true. While setting the property, it is calling the busctl set-property method, which updates the data only on DBus and data is not persisted.

When BMC is rebooted while host is running, on system come back, the stale data of the FRU which has functional as false will get updated on the DBus, which marks that FRU as critical on ASMI.

Changes made to use Phosphor Inventory Manager(PIM) notify method to update the functional property, which publish the data on Dbus and persist the data.