### PR TITLE
Notify PIM to update functional property

### DIFF
--- a/ibm-sai.cpp
+++ b/ibm-sai.cpp
@@ -54,10 +54,10 @@ void setOperationalStatus(const std::string& path, bool value)
         try
         {
             utils::PropertyValue functionalValue{value};
-            utils::DBusHandler().setProperty(
-                fruInstancePath,
-                "xyz.openbmc_project.State.Decorator.OperationalStatus",
-                "Functional", functionalValue);
+            utils::DBusHandler().notifyPIM(
+                {{fruInstancePath,
+                  {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                    {{"Functional", functionalValue}}}}}});
         }
         catch (const sdbusplus::exception::SdBusError& e)
         {

--- a/scripts/oem/set-guarded-fru-leds.sh
+++ b/scripts/oem/set-guarded-fru-leds.sh
@@ -37,9 +37,15 @@ do
         echo "$line2" | grep "dimm" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then
-            busctl set-property xyz.openbmc_project.Inventory.Manager \
-                "$line2" xyz.openbmc_project.State.Decorator.OperationalStatus \
-                Functional b false;
+            echo "$line2" | grep "/xyz/openbmc_project/inventory" >/dev/null
+            rc=$?
+            if [ $rc -eq 0 ]; then
+                line2=$(echo "$line2" | sed 's|/xyz/openbmc_project/inventory||');
+                busctl call xyz.openbmc_project.Inventory.Manager \
+                    /xyz/openbmc_project/inventory xyz.openbmc_project.Inventory.Manager \
+                    Notify a\{oa\{sa\{sv\}\}\} \
+                    1 "$line2" 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" 1 "Functional" b false;
+            fi
         fi
 
         #check for guarded processors and update its operational status.
@@ -49,9 +55,15 @@ do
             echo "$line2" | grep "unit\|core" >/dev/null
             rc=$?
             if [ $rc -ne 0 ]; then
-                busctl set-property xyz.openbmc_project.Inventory.Manager \
-                    "$line2" xyz.openbmc_project.State.Decorator.OperationalStatus \
-                    Functional b false;
+                echo "$line2" | grep "/xyz/openbmc_project/inventory" >/dev/null
+                rc=$?
+                if [ $rc -eq 0 ]; then
+                    line2=$(echo "$line2" | sed 's|/xyz/openbmc_project/inventory||');
+                    busctl call xyz.openbmc_project.Inventory.Manager \
+                        /xyz/openbmc_project/inventory xyz.openbmc_project.Inventory.Manager \
+                        Notify a\{oa\{sa\{sv\}\}\} \
+                        1 "$line2" 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" 1 "Functional" b false;
+                fi
             fi
         fi
     done

--- a/scripts/oem/set-power-button-led-to-default-state.sh
+++ b/scripts/oem/set-power-button-led-to-default-state.sh
@@ -6,8 +6,8 @@
 current_chassis_status=$(busctl get-property xyz.openbmc_project.State.Chassis /xyz/openbmc_project/state/chassis0 xyz.openbmc_project.State.Chassis CurrentPowerState | cut -d" " -f2)
 
 if [ "${current_chassis_status}" = "\"xyz.openbmc_project.State.Chassis.PowerState.On\"" ]; then
-	    echo "Current chassis power state is , $current_chassis_status . Exit set-power-button-led-to-default-state.sh script successfully without initialising the LEDs"
-	    exit 0
+    echo "Current chassis power state is , $current_chassis_status . Exit set-power-button-led-to-default-state.sh script successfully without initialising the LEDs"
+    exit 0
 fi
 
 # Explicitly set Blink as the default state

--- a/utils.cpp
+++ b/utils.cpp
@@ -126,6 +126,30 @@ const std::vector<std::string>
     return paths;
 }
 
+void DBusHandler::notifyPIM(ObjectMap&& objectMap)
+{
+    for (const auto& objectKeyValue : objectMap)
+    {
+        auto objectPath = objectMap.extract(objectKeyValue.first);
+
+        if (objectPath.key().str.find("/xyz/openbmc_project/inventory", 0) !=
+            std::string::npos)
+        {
+            objectPath.key() = objectPath.key().str.replace(
+                0, strlen("/xyz/openbmc_project/inventory"), "");
+            objectMap.insert(std::move(objectPath));
+        }
+    }
+
+    auto bus = sdbusplus::bus::new_default();
+    auto pimMsg =
+        bus.new_method_call("xyz.openbmc_project.Inventory.Manager",
+                            "/xyz/openbmc_project/inventory",
+                            "xyz.openbmc_project.Inventory.Manager", "Notify");
+    pimMsg.append(std::move(objectMap));
+    bus.call(pimMsg);
+}
+
 } // namespace utils
 } // namespace led
 } // namespace phosphor

--- a/utils.hpp
+++ b/utils.hpp
@@ -32,6 +32,10 @@ using DbusProperty = std::string;
 // The Map to constructs all properties values of the interface
 using PropertyMap = std::map<DbusProperty, PropertyValue>;
 
+using ObjectMap =
+    std::map<sdbusplus::message::object_path,
+             std::map<std::string, std::map<std::string, PropertyValue>>>;
+
 /**
  *  @class DBusHandler
  *
@@ -111,6 +115,18 @@ class DBusHandler
     const std::vector<std::string>
         getSubTreePaths(const std::string& objectPath,
                         const std::string& interface);
+
+    /**
+     * @brief An API to call PIM
+     *
+     * This API calls notify method of PIM to update the property value.
+     *
+     * @param[in] objectMap - Map of object path, interface, property and its
+     * value.
+     *
+     * @throw sdbusplus::exception_t when it fails
+     */
+    void notifyPIM(ObjectMap&& objectMap);
 };
 
 } // namespace utils


### PR DESCRIPTION
Functional property of a FRU which is populated under the Phosphor Inventory Manager(PIM) service will have persisted value. Updating the functional property value using busctl set-property method is creating a mismatch between persisted data and the data populated on DBus, as set-property method updates the data only on the DBus. This is causing the
mismatch of the state of the FRU before and after the BMC reboot while host is running, as DBus picks the value from the stale data while host is running. 

Updated to call Notify method of PIM service which updates data on both persisted and on the DBus.
