### PR TITLE
Balcones LED config JSON

### DIFF
--- a/configs/com.ibm.Hardware.Chassis.Model.Balcones.json
+++ b/configs/com.ibm.Hardware.Chassis.Model.Balcones.json
@@ -1,0 +1,1840 @@
+{
+   "leds":[
+      {
+         "group":"bmc_booted",
+         "members":[
+            {
+               "Name":"pca955x_front_sys_pwron0",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"power_on",
+         "members":[
+            {
+               "Name":"pca955x_front_sys_pwron0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"partition_system_attention_indicator",
+         "members":[
+            {
+               "Name":"pca955x_front_check_log0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"platform_system_attention_indicator",
+         "members":[
+            {
+               "Name":"pca955x_front_check_log0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"enclosure_fault",
+         "members":[
+            {
+               "Name":"pca955x_front_enc_fault1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_fault0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_fault",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"enclosure_identify",
+         "members":[
+            {
+               "Name":"pca955x_front_sys_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_id",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"fan0_fault",
+         "members":[
+            {
+               "Name":"led_fan0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_enc_fault1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_fault0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_fault",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"fan0_identify",
+         "members":[
+            {
+               "Name":"led_fan0",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_sys_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_id",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"fan1_fault",
+         "members":[
+            {
+               "Name":"led_fan1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_enc_fault1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_fault0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_fault",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"fan1_identify",
+         "members":[
+            {
+               "Name":"led_fan1",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_sys_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_id",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme0_fault",
+         "members":[
+            {
+               "Name":"pca955x_nvme0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_enc_fault1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_fault0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_fault",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme0_identify",
+         "members":[
+            {
+               "Name":"pca955x_nvme0",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_sys_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_id",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme1_fault",
+         "members":[
+            {
+               "Name":"pca955x_nvme1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_enc_fault1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_fault0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_fault",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme1_identify",
+         "members":[
+            {
+               "Name":"pca955x_nvme1",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_sys_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_id",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme2_fault",
+         "members":[
+            {
+               "Name":"pca955x_nvme2",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_enc_fault1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_fault0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_fault",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme2_identify",
+         "members":[
+            {
+               "Name":"pca955x_nvme2",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_sys_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_id",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme3_fault",
+         "members":[
+            {
+               "Name":"pca955x_nvme3",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_enc_fault1",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_fault0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_fault",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group":"nvme3_identify",
+         "members":[
+            {
+               "Name":"pca955x_nvme3",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"Blink"
+            },
+            {
+               "Name":"pca955x_front_sys_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"led_rear_enc_id0",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            },
+            {
+               "Name":"virtual_enc_id",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"On"
+            }
+         ]
+      },
+      {
+         "group" : "powersupply0_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "powersupply0_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "powersupply1_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "powersupply1_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot0_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot0_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot1_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot1_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot2_fault",
+         "members" : [
+             {
+               "Name":"pca955x_pcieslot2",
+               "Action":"On",
+               "DutyOn":50,
+               "Period":0,
+               "Priority":"Blink"
+	     },
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot2_identify",
+         "members" : [
+	     {
+               "Name":"pca955x_pcieslot2",
+               "Action":"Blink",
+               "DutyOn":50,
+               "Period":1000,
+               "Priority":"Blink"
+	     },
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot3_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "pcieslot3_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "usb0_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }, 
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "ethernet0_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector2_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector3_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector4_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector5_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector6_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector8_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector9_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector10_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector11_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector12_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "connector13_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "tpm_wilson_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "tpm_wilson_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "base_op_panel_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "base_op_panel_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "lcd_panel_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "lcd_panel_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "planar_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "planar_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "cpu_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "cpu_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "disk_backplane0_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "disk_backplane0_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dp0_connector0_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dp0_connector1_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dp0_connector2_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dp0_connector3_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm0_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm0_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm1_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm1_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm2_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm2_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm3_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "dimm3_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "rtc_battery_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "rtc_battery_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      }
+   ]
+}

--- a/configs/config_map.json
+++ b/configs/config_map.json
@@ -6,7 +6,7 @@
         "Rainier 4U": "com.ibm.Hardware.Chassis.Model.Rainier4U",
         "Rainier 4U Pass 1": "com.ibm.Hardware.Chassis.Model.Rainier4U",
         "Everest": "com.ibm.Hardware.Chassis.Model.Everest",
-        "Bonnell": "com.ibm.Hardware.Chassis.Model.Bonnell",
+        "Balcones": "com.ibm.Hardware.Chassis.Model.Balcones",
         "Blueridge 1S4U": "com.ibm.Hardware.Chassis.Model.BlueRidge1S4U",
         "Blueridge 2U": "com.ibm.Hardware.Chassis.Model.BlueRidge2U",
         "Blueridge 2U Pass 1": "com.ibm.Hardware.Chassis.Model.BlueRidge2U",


### PR DESCRIPTION
This commit has led config JSON for Balcones.

Test:
Tested on Bonnell by overwriting the bonnell json
with balcones json and verified that the below
test cases works fine.

1. BMC booted
2. Power on
3. Balcones doesn't support RDX docking station, RDX power cable port, RDX media, USB connector and power connector. Tested that the identify LED request fails on these devices on Bonnell.

busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/rdx0_identify xyz.openbmc_project.Led.Group  Asserted b true Failed to set property Asserted on interface xyz.openbmc_project.Led.Group: Unknown object '/xyz/openbmc_project/led/groups/rdx0_identify'.

4. Identify request for fans/psu/cpu/connectors works as expected from GUI.
5. Identify request for system identify led from GUI works as expected.
6. Panel lamp test works as expected.

Change-Id: I0514c31e6aa8120aa762ad0f6ecda463d1fd2753