### PR TITLE
Add sync fault LED option stub in led-tool

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,6 +1,7 @@
 #include "clear-psu-fault-leds.hpp"
 #include "set-guarded-fru-leds.hpp"
 #include "set-leds-default-state.hpp"
+#include "sync-fault-leds.hpp"
 #include "toggle-fault-leds.hpp"
 
 #include <CLI/CLI.hpp>
@@ -32,6 +33,14 @@ int main(int argc, char** argv)
     auto clearPsuFaultLed = app.add_flag("-c, --clearPsuFaultLed",
                                          "Clears PSU fault LEDs.");
 
+    std::string objectPath;
+    auto objectPathOption = app.add_option("-o, --object", objectPath,
+                                           "Object path of the FRU.");
+    auto syncFaultLed =
+        app.add_flag("-q, --syncFaultLed",
+                     "Syncs fault LEDs to functional state of the FRU.")
+            ->needs(objectPathOption);
+
     CLI11_PARSE(app, argc, argv);
 
     try
@@ -54,6 +63,11 @@ int main(int argc, char** argv)
         if (*clearPsuFaultLed)
         {
             clearPsuFaultLeds();
+        }
+
+        if (!syncFaultLed->empty())
+        {
+            doSyncFaultLed(objectPath);
         }
     }
     catch (const std::exception& ex)

--- a/tools/sync-fault-leds.hpp
+++ b/tools/sync-fault-leds.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "utility.hpp"
+
+/** @brief API to sync asserted and state properties of a fault LED of a FRU.
+ *
+ * This API syncs asserted and state properties of a fault LED of a FRU
+ * according to the functional property of the FRU.
+ *
+ * @param[in] i_objectPath - Object path of FRU
+ *
+ * @throw std::runtime_error
+ */
+void doSyncFaultLed([[maybe_unused]] const std::string& i_objectPath)
+{
+    // TODO:
+    // 1. For given object path, get the Functional property from PIM
+    // 2. Construct associated fault LED object path and get the Asserted
+    //    property from LED.Group
+    //    If Asserted property is incorrect, update it.
+    // 3. Construct associated physical LED object path and get the State
+    //    property from LED.Controller.pca955x_* service.
+    //    If State property is incorrect, update it.
+}


### PR DESCRIPTION
This commit adds an option in led-tool to sync asserted and state properties of the fault LED of a FRU according to the functional property of the FRU. This is a stub implementation, and actual implementation will be handled in a later commit.