### PR TITLE
Change error handling in tool getProperty API

### DIFF
--- a/tools/clear-psu-fault-leds.hpp
+++ b/tools/clear-psu-fault-leds.hpp
@@ -89,11 +89,10 @@ void clearPsuFaultLeds()
               {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
                 {{"Functional", true}}}}}});
 
-        auto retVal =
-            utility::getProperty<std::variant<std::vector<std::string>>>(
-                "xyz.openbmc_project.ObjectMapper",
-                objectPath + "/fault_identifying",
-                "xyz.openbmc_project.Association", "endpoints");
+        auto retVal = utility::getProperty("xyz.openbmc_project.ObjectMapper",
+                                           objectPath + "/fault_identifying",
+                                           "xyz.openbmc_project.Association",
+                                           "endpoints");
 
         if (auto endpoints = std::get_if<std::vector<std::string>>(&retVal))
         {

--- a/tools/set-guarded-fru-leds.hpp
+++ b/tools/set-guarded-fru-leds.hpp
@@ -42,8 +42,7 @@ void setLEDForGuardedFru()
 
     for (const auto& [objectPath, serviceInterfceMap] : subTree)
     {
-        auto retVal = utility::getProperty<std::variant<
-            std::vector<std::tuple<std::string, std::string, std::string>>>>(
+        auto retVal = utility::getProperty(
             "org.open_power.HardwareIsolation", objectPath,
             "xyz.openbmc_project.Association.Definitions", "Associations");
 

--- a/tools/toggle-fault-leds.hpp
+++ b/tools/toggle-fault-leds.hpp
@@ -78,11 +78,10 @@ void toggleFaultLeds(const bool isFunctional)
             continue;
         }
 
-        auto retVal =
-            utility::getProperty<std::variant<std::vector<std::string>>>(
-                "xyz.openbmc_project.ObjectMapper",
-                objectPath + "/fault_identifying",
-                "xyz.openbmc_project.Association", "endpoints");
+        auto retVal = utility::getProperty("xyz.openbmc_project.ObjectMapper",
+                                           objectPath + "/fault_identifying",
+                                           "xyz.openbmc_project.Association",
+                                           "endpoints");
 
         if (auto endpoints = std::get_if<std::vector<std::string>>(&retVal))
         {

--- a/tools/utility.hpp
+++ b/tools/utility.hpp
@@ -10,6 +10,34 @@
 namespace utility
 {
 
+// This covers mostly all the data type supported over Dbus for a property.
+// clang-format off
+using DbusVariantType = std::variant<
+    std::monostate,
+    std::vector<std::tuple<std::string, std::string, std::string>>,
+    std::vector<std::string>,
+    std::vector<double>,
+    std::string,
+    int64_t,
+    uint64_t,
+    double,
+    int32_t,
+    uint32_t,
+    int16_t,
+    uint16_t,
+    uint8_t,
+    bool,
+    std::vector<uint32_t>,
+    std::vector<uint16_t>,
+    sdbusplus::message::object_path,
+    std::tuple<uint64_t, std::vector<std::tuple<std::string, std::string, double, uint64_t>>>,
+    std::vector<std::tuple<std::string, std::string>>,
+    std::vector<std::tuple<uint32_t, std::vector<uint32_t>>>,
+    std::vector<std::tuple<uint32_t, size_t>>,
+    std::vector<std::tuple<sdbusplus::message::object_path, std::string,
+                           std::string, std::string>>
+>;
+
 /**
  * @brief An API to make GetSubTree mapper call.
  *
@@ -133,21 +161,25 @@ void setProperty(const std::string& serviceName, const std::string& objectPath,
  * @param[in] property - D-Bus property whose value is to be fetched.
  * @return Value of the property.
  */
-template <typename T>
-T getProperty(const std::string& serviceName, const std::string& objectPath,
+DbusVariantType getProperty(const std::string& serviceName, const std::string& objectPath,
               const std::string& interface, const std::string& property)
 {
-    auto bus = sdbusplus::bus::new_default();
-    auto mapperCall =
+    DbusVariantType result;
+
+    if(serviceName.empty() || objectPath.empty() || interface.empty() || property.empty())
+    {
+        std::cout << "One of the parameters required to make Dbus get call is empty" << std::endl;
+        return result;
+    }
+
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto mapperCall =
         bus.new_method_call(serviceName.c_str(), objectPath.c_str(),
                             "org.freedesktop.DBus.Properties", "Get");
     mapperCall.append(interface);
     mapperCall.append(property);
-
-    T result = {};
-
-    try
-    {
         auto response = bus.call(mapperCall);
 
         response.read(result);
@@ -169,7 +201,7 @@ T getProperty(const std::string& serviceName, const std::string& objectPath,
  */
 bool isChassisOn()
 {
-    auto retVal = getProperty<std::variant<std::string>>(
+    auto retVal = getProperty(
         "xyz.openbmc_project.State.Chassis0",
         "/xyz/openbmc_project/state/chassis0",
         "xyz.openbmc_project.State.Chassis", "CurrentPowerState");


### PR DESCRIPTION
getProperty utility API in led-tool was returning default value in error condition. The callers of this API had no way to detect error. getProperty API now returns a variant with type as std::monostate on error, which allows callers of this API to detect error.