### PR TITLE
manager: rate limit dbus errors

### DIFF
--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -7,9 +7,11 @@
 #include <xyz/openbmc_project/Led/Physical/server.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <iostream>
 #include <string>
+
 namespace phosphor
 {
 namespace led
@@ -206,10 +208,24 @@ int Manager::drivePhysicalLED(const std::string& objPath, Layout::Action action,
             return -1;
         }
 
+        // This can be a really spammy event log, so we rate limit it to once an
+        // hour per LED.
+        auto now = std::chrono::steady_clock::now();
+
+        if (auto it = physicalLEDErrors.find(objPath);
+            it != physicalLEDErrors.end())
+        {
+            using namespace std::literals::chrono_literals;
+            if ((now - it->second) < 1h)
+            {
+                return -1;
+            }
+        }
+
         lg2::error(
             "Error setting property for physical LED, ERROR = {ERROR}, OBJECT_PATH = {PATH}",
             "ERROR", e, "PATH", objPath);
-
+        physicalLEDErrors[objPath] = now;
         return -1;
     }
 

--- a/manager/manager.hpp
+++ b/manager/manager.hpp
@@ -6,6 +6,7 @@
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/utility/timer.hpp>
 
+#include <chrono>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -177,6 +178,11 @@ class Manager
 
     /** @brief Contains the required set of deassert LEDs action */
     ActionSet reqLedsDeAssert;
+
+    /** @brief Map to store the last error time for physical LED paths */
+    std::unordered_map<std::string,
+                       std::chrono::time_point<std::chrono::steady_clock>>
+        physicalLEDErrors;
 
     /** @brief LEDs handler callback */
     void driveLedsHandler();


### PR DESCRIPTION
If there is a misconfiguration between sysfs and led-manager, the manager will be very spammy about dbus errors at it tries to update the sysfs value.  Rate limit this to once per hour per LED.


Change-Id: I2896377ff64318159ca3963d09c2ab5bf7452862