### PR TITLE
led-tool:Add override option for chassis on check

### DIFF
--- a/tools/clear-psu-fault-leds.hpp
+++ b/tools/clear-psu-fault-leds.hpp
@@ -15,8 +15,11 @@
  * which the call to fetch endpoints would fail.
  * Explicit dependency for LED is not added in service as it will delay the
  * execution further and clearing of PSU LED should happen asap.
+ *
+ * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
-void clearPsuFaultLeds()
+void clearPsuFaultLeds(
+    [[maybe_unused]] const bool overrideChassisOnCheck = false)
 {
     // sufficiently large number within which the LED service should come up.
     static constexpr auto MAX_RETRY = 120;

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -33,6 +33,9 @@ int main(int argc, char** argv)
     auto clearPsuFaultLed = app.add_flag("-c, --clearPsuFaultLed",
                                          "Clears PSU fault LEDs.");
 
+    auto overrideChassisOnCheckOption = app.add_flag(
+        "-x, --overrideChassisOnCheck", "Flag to override chassis on check.");
+
     std::string objectPath;
     auto objectPathOption = app.add_option("-o, --object", objectPath,
                                            "Object path of the FRU.");
@@ -47,22 +50,23 @@ int main(int argc, char** argv)
     {
         if (*toggleFaultLed)
         {
-            toggleFaultLeds(isFunctional);
+            toggleFaultLeds(isFunctional,
+                            !overrideChassisOnCheckOption->empty());
         }
 
         if (*setGuardedFruLeds)
         {
-            setLEDForGuardedFru();
+            setLEDForGuardedFru(!overrideChassisOnCheckOption->empty());
         }
 
         if (*defaultLedsSate)
         {
-            setLedsDefaultState();
+            setLedsDefaultState(!overrideChassisOnCheckOption->empty());
         }
 
         if (*clearPsuFaultLed)
         {
-            clearPsuFaultLeds();
+            clearPsuFaultLeds(!overrideChassisOnCheckOption->empty());
         }
 
         if (!syncFaultLed->empty())

--- a/tools/set-guarded-fru-leds.hpp
+++ b/tools/set-guarded-fru-leds.hpp
@@ -10,8 +10,11 @@
  * executed.
  * It checks for existing guard records and set LEDs asserted state for them as
  * true if required.
+ *
+ * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
-void setLEDForGuardedFru()
+void setLEDForGuardedFru(
+    [[maybe_unused]] const bool overrideChassisOnCheck = false)
 {
     std::cout << "Trigger set LED for guarded FRUs" << std::endl;
 

--- a/tools/set-leds-default-state.hpp
+++ b/tools/set-leds-default-state.hpp
@@ -22,8 +22,11 @@ void setAssertedToFalse(const std::string ObjectPath)
  * accordingly. Enclosure identify - need not be persisted.
  * Explicitly Asserted being set as there is no operational status associated
  * these LEDs.
+ *
+ * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
-void setLedsDefaultState()
+void setLedsDefaultState(
+    [[maybe_unused]] const bool overrideChassisOnCheck = false)
 {
     std::cout << "Trigger set default state for LEDs." << std::endl;
 

--- a/tools/toggle-fault-leds.hpp
+++ b/tools/toggle-fault-leds.hpp
@@ -15,8 +15,10 @@
  * - Operational status of the FRU is handled by some other module.
  *
  * @param[in] isFunctional - States if the FRUs are functional or not.
+ * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
-void toggleFaultLeds(const bool isFunctional)
+void toggleFaultLeds(const bool isFunctional,
+                     [[maybe_unused]] const bool overrideChassisOnCheck = false)
 {
     std::cout << "Trigger toggling of fault LEDs with value: " << isFunctional
               << std::endl;


### PR DESCRIPTION
This commit adds an option in led-tool to override chassis on check. Some of the led-tool options block execution if chassis is on. This new option allows user to override this check. This is a stub implementation and actual implementation shall be handled in a future commit.