### PR TITLE
led-tool:implement chassis on check override option

### DIFF
--- a/tools/clear-psu-fault-leds.hpp
+++ b/tools/clear-psu-fault-leds.hpp
@@ -18,19 +18,27 @@
  *
  * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
-void clearPsuFaultLeds(
-    [[maybe_unused]] const bool overrideChassisOnCheck = false)
+void clearPsuFaultLeds(const bool overrideChassisOnCheck = false)
 {
     // sufficiently large number within which the LED service should come up.
     static constexpr auto MAX_RETRY = 120;
 
     if (utility::isChassisOn())
     {
-        std::cout
-            << "Abort clearing PSU fault LED. Chassis is in power on state."
-            << std::endl;
+        if (!overrideChassisOnCheck)
+        {
+            std::cout
+                << "Abort clearing PSU fault LEDs because the chassis is powered on."
+                << std::endl;
 
-        return;
+            return;
+        }
+
+        utility::createPel(
+            __FILE__, __FUNCTION__,
+            "Clearing PSU fault LEDs while chassis is on",
+            "xyz.openbmc_project.Common.Error.NotAllowed",
+            "xyz.openbmc_project.Logging.Entry.Level.Informational");
     }
 
     std::vector<std::string> interfaces{

--- a/tools/set-guarded-fru-leds.hpp
+++ b/tools/set-guarded-fru-leds.hpp
@@ -13,18 +13,25 @@
  *
  * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
-void setLEDForGuardedFru(
-    [[maybe_unused]] const bool overrideChassisOnCheck = false)
+void setLEDForGuardedFru(const bool overrideChassisOnCheck = false)
 {
     std::cout << "Trigger set LED for guarded FRUs" << std::endl;
 
     if (utility::isChassisOn())
     {
-        std::cout
-            << "Abort set led for guarded FRUs as chassis is in power on state."
-            << std::endl;
+        if (!overrideChassisOnCheck)
+        {
+            std::cout
+                << "Abort set LED for guarded FRUs as chassis is in power on state."
+                << std::endl;
 
-        return;
+            return;
+        }
+        utility::createPel(
+            __FILE__, __FUNCTION__,
+            "Setting LEDs for guarded FRUs while chassis is on",
+            "xyz.openbmc_project.Common.Error.NotAllowed",
+            "xyz.openbmc_project.Logging.Entry.Level.Informational");
     }
 
     std::vector<std::string> interfaces{

--- a/tools/set-leds-default-state.hpp
+++ b/tools/set-leds-default-state.hpp
@@ -25,18 +25,26 @@ void setAssertedToFalse(const std::string ObjectPath)
  *
  * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
-void setLedsDefaultState(
-    [[maybe_unused]] const bool overrideChassisOnCheck = false)
+void setLedsDefaultState(const bool overrideChassisOnCheck = false)
 {
     std::cout << "Trigger set default state for LEDs." << std::endl;
 
     if (utility::isChassisOn())
     {
-        std::cout
-            << "Abort setting LEDs to default as chassis is in power on state."
-            << std::endl;
+        if (!overrideChassisOnCheck)
+        {
+            std::cout
+                << "Abort setting LEDs to default as chassis is in power on state."
+                << std::endl;
 
-        return;
+            return;
+        }
+
+        utility::createPel(
+            __FILE__, __FUNCTION__,
+            "Setting LEDs to default state while chassis is on",
+            "xyz.openbmc_project.Common.Error.NotAllowed",
+            "xyz.openbmc_project.Logging.Entry.Level.Informational");
     }
 
     // set default state for power button.

--- a/tools/toggle-fault-leds.hpp
+++ b/tools/toggle-fault-leds.hpp
@@ -18,7 +18,7 @@
  * @param[in] overrideChassisOnCheck - Flag to override chassis on check.
  */
 void toggleFaultLeds(const bool isFunctional,
-                     [[maybe_unused]] const bool overrideChassisOnCheck = false)
+                     const bool overrideChassisOnCheck = false)
 {
     std::cout << "Trigger toggling of fault LEDs with value: " << isFunctional
               << std::endl;
@@ -33,10 +33,19 @@ void toggleFaultLeds(const bool isFunctional,
 
     if (utility::isChassisOn())
     {
-        std::cout << "Abort toggling fault LED. Chassis is in power on state."
-                  << std::endl;
+        if (!overrideChassisOnCheck)
+        {
+            std::cout
+                << "Abort toggling fault LEDs. Chassis is in power on state."
+                << std::endl;
 
-        return;
+            return;
+        }
+
+        utility::createPel(
+            __FILE__, __FUNCTION__, "Toggle Fault LEDs while chassis is on",
+            "xyz.openbmc_project.Common.Error.NotAllowed",
+            "xyz.openbmc_project.Logging.Entry.Level.Informational");
     }
 
     std::vector<std::string> interfaces{

--- a/tools/utility.hpp
+++ b/tools/utility.hpp
@@ -265,4 +265,46 @@ void notifyPIM(ObjectMap&& objectMap)
                   << e.what() << std::endl;
     }
 }
+
+/**
+ * @brief API to create a PEL
+ *
+ * This API makes synchronous call to phosphor-logging Create method.
+ *
+ * @param[in] i_fileName - File name.
+ * @param[in] i_funcName - Function name.
+ * @param[in] i_description - Error description.
+ * @param[in] i_errorType - Error type as per PEL message registry.
+ * @param[in] i_severity - Severity level.
+ *
+ */
+void createPel(const std::string& i_fileName,
+        const std::string& i_funcName,
+        const std::string& i_description, const std::string& i_errorType, const std::string& i_severity) noexcept
+{
+    try
+    {
+        if(i_fileName.empty() || i_funcName.empty() || i_description.empty() || i_errorType.empty() || i_severity.empty())
+        {
+            throw std::runtime_error("Invalid parameters for creating PEL");
+        }
+
+        auto l_bus = sdbusplus::bus::new_default();
+        auto l_method =
+            l_bus.new_method_call("xyz.openbmc_project.Logging",
+                                  "/xyz/openbmc_project/logging",
+                                  "xyz.openbmc_project.Logging.Create", "Create");
+
+        const std::map<std::string, std::string> l_additionalData{{"FileName", i_fileName},
+            {"FunctionName", i_funcName},
+            {"DESCRIPTION", i_description}};
+
+        l_method.append(i_errorType,i_severity,l_additionalData);
+        l_bus.call(l_method);
+    }
+    catch(const std::exception& l_ex)
+    {
+        std::cerr << "Failed to create PEL. Error: " << std::string(l_ex.what()) << std::endl;
+    }
+}
 } // namespace utility


### PR DESCRIPTION
This commit implements option to override chassis on check. Some of the
    led-tool options block execution if chassis is on. This option allows
    user to override this check and continue execution. If user overrides
    chassis on check, informational PEL is logged.