### PR TITLE
Add dump flag to LED tool

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char** argv)
                      "Syncs fault LEDs to functional state of the FRU.")
             ->needs(objectPathOption);
 
+    auto dumpLedObjectPaths = app.add_flag(
+        "-D, --dumpLedObjectPaths", "Dumps LED object paths on console.");
+
     CLI11_PARSE(app, argc, argv);
 
     try
@@ -69,6 +72,9 @@ int main(int argc, char** argv)
         {
             doSyncFaultLed(objectPath);
         }
+
+        if (!dumpLedObjectPaths->empty())
+        {}
     }
     catch (const std::exception& ex)
     {


### PR DESCRIPTION
This commit adds dump flag for LED tool. This flag will be used for dumping LED object paths on console.
This commit just adds dump flag, options related to this flag will be implemented in future commits.

output:
```
root@p10bmc:# led-tool --help
led-tool - A tool to perform opeartion(s) over LEDs.
Usage: ./led-tool [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  -f,--functional BOOLEAN     True/False depending upon the functional status of FRU.
  -t,--toggleFaultLeds Needs: --functional
                              Toggles asserted property for fault LEDs according to the functional status passed. Also updates functional property of the FRUs hosted under PIM accordingly.
  -s,--setGuardedFruLeds      Set LEDs for guarded FRUs.
  -d,--defaultLedsState       Sets power, enclosure fault, SAI and enclosure identify to default state.
  -c,--clearPsuFaultLed       Clears PSU fault LEDs.
  -o,--object TEXT            Object path of the FRU.
  -q,--syncFaultLed Needs: --object
                              Syncs fault LEDs to functional state of the FRU.
  -D,--dumpLedObjectPaths     Dumps LED object paths on console.
```
