### PR TITLE
Flag to dump asserted LED paths from led-tool

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -5,10 +5,60 @@
 #include "toggle-fault-leds.hpp"
 
 #include <CLI/CLI.hpp>
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+/**
+ * @brief An API to dump asserted LED paths to console.
+ *
+ * @returns 0 for success, -1 for failure.
+ */
+int dumpAssertedLedObjectPaths()
+{
+    const std::string savedGroupsPath =
+        "/var/lib/phosphor-led-manager/savedGroups";
+    try
+    {
+        if (std::filesystem::exists(savedGroupsPath))
+        {
+            std::ifstream ledsFilePath(savedGroupsPath);
+
+            if (!ledsFilePath)
+            {
+                throw std::runtime_error(
+                    "Unable to open saved groups file. Can't dump LED path(s).");
+            }
+
+            const nlohmann::json parsedLedFile =
+                nlohmann::json::parse(ledsFilePath);
+
+            for (const auto& ledPath : parsedLedFile["value0"])
+            {
+                std::cout << ledPath << std::endl;
+            }
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Saved groups file is not present. Can't dump LED path(s).");
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "Error while trying to dump asserted led paths. Error : "
+                  << ex.what() << std::endl;
+
+        return -1;
+    }
+
+    return 0;
+}
 
 int main(int argc, char** argv)
 {
-    CLI::App app{"led-tool - A tool to perform opeartion(s) over LEDs."};
+    CLI::App app{"led-tool - A tool to perform operation(s) over LEDs."};
 
     bool isFunctional = true;
     auto functional = app.add_option(
@@ -47,6 +97,11 @@ int main(int argc, char** argv)
     auto dumpLedObjectPaths = app.add_flag(
         "-D, --dumpLedObjectPaths", "Dumps LED object paths on console.");
 
+    auto dumpAssertedLeds =
+        app.add_flag("-a, --dumpAssertedLeds",
+                     "Dumps asserted LED object paths to the console.")
+            ->needs(dumpLedObjectPaths);
+
     CLI11_PARSE(app, argc, argv);
 
     try
@@ -78,7 +133,12 @@ int main(int argc, char** argv)
         }
 
         if (!dumpLedObjectPaths->empty())
-        {}
+        {
+            if (!dumpAssertedLeds->empty())
+            {
+                return dumpAssertedLedObjectPaths();
+            }
+        }
     }
     catch (const std::exception& ex)
     {


### PR DESCRIPTION
This commit adds flag to dump asserted led object paths to console from led-tool.

output:
```
root@p10bmc:~# led-tool --help
led-tool - A tool to perform operation(s) over LEDs.
Usage: led-tool [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  -f,--functional BOOLEAN     True/False depending upon the functional status of FRU.
  -t,--toggleFaultLeds Needs: --functional
                              Toggles asserted property for fault LEDs according to the functional status passed. Also updates functional property of the FRUs hosted under PIM accordingly.
  -s,--setGuardedFruLeds      Set LEDs for guarded FRUs.
  -d,--defaultLedsState       Sets power, enclosure fault, SAI and enclosure identify to default state.
  -c,--clearPsuFaultLed       Clears PSU fault LEDs.
  -x,--overrideChassisOnCheck Flag to override chassis on check.
  -o,--object TEXT            Object path of the FRU.
  -q,--syncFaultLed Needs: --object
                              Syncs fault LEDs to functional state of the FRU.
  -D,--dumpLedObjectPaths     Dumps LED object paths on console.
  -a,--dumpAssertedLeds Needs: --dumpLedObjectPaths
                              Dumps asserted LED object paths to the console.

root@p10bmc:~# led-tool -D -a
"/xyz/openbmc_project/led/groups/bmc_booted"
'''