### PR TITLE
Dump LED path with inventory path on the console

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 
 /**
  * @brief An API to dump asserted LED paths to console.
@@ -49,6 +50,75 @@ int dumpAssertedLedObjectPaths()
     {
         std::cerr << "Error while trying to dump asserted led paths. Error : "
                   << ex.what() << std::endl;
+
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief An API to dump LED path with inventory path.
+ *
+ * This API dumps lED path with its associated inventory paths on the console.
+ *
+ * @returns 0 for success, -1 for failure.
+ */
+int dumpLedPathWithInventoryPath()
+{
+    try
+    {
+        std::cout << std::setfill('=') << std::setw(150) << "" << std::endl;
+
+        std::cout << std::left << std::setw(70) << std::setfill(' ')
+                  << "LED path"
+                  << " | " << std::left << std::setw(80) << std::setfill(' ')
+                  << "Inventory Path" << std::endl;
+
+        std::cout << std::setfill('=') << std::setw(150) << "" << std::endl;
+
+        auto objectSubTreeMap = utility::getObjectSubtreeForInterfaces(
+            "/xyz/openbmc_project/inventory/system", 0,
+            {"xyz.openbmc_project.Association.Definitions"});
+
+        for (const auto& objectInterfaceMap : objectSubTreeMap)
+        {
+            const std::string& inventoryPath = objectInterfaceMap.first;
+
+            auto faultLedPath = utility::GetAssociatedSubTreePaths(
+                std::string(inventoryPath + "/fault_identifying"),
+                std::string("/"), 0, {});
+
+            auto identifyLedPath = utility::GetAssociatedSubTreePaths(
+                std::string(inventoryPath + "/identifying"), std::string("/"),
+                0, {});
+
+            for (const auto& ledPath : faultLedPath)
+            {
+                std::cout << std::left << std::setw(70) << std::setfill(' ')
+                          << ledPath << " | " << std::left << std::setw(80)
+                          << std::setfill(' ') << inventoryPath << std::endl;
+
+                std::cout << std::setfill('-') << std::setw(150) << ""
+                          << std::endl;
+            }
+
+            for (const auto& ledPath : identifyLedPath)
+            {
+                std::cout << std::left << std::setw(70) << std::setfill(' ')
+                          << ledPath << " | " << std::left << std::setw(80)
+                          << std::setfill(' ') << inventoryPath << std::endl;
+
+                std::cout << std::setfill('-') << std::setw(150) << ""
+                          << std::endl;
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Error while dumping LED paths with inventory paths to the console. Error : "
+            << e.what() << std::endl;
 
         return -1;
     }
@@ -102,6 +172,12 @@ int main(int argc, char** argv)
                      "Dumps asserted LED object paths to the console.")
             ->needs(dumpLedObjectPaths);
 
+    auto dumpInventoryPathWithLedPath =
+        app.add_flag(
+               "-i, --dumpInventoryPathWithLedPath",
+               "Dumps LED path with its associated inventory path to the console.")
+            ->needs(dumpLedObjectPaths);
+
     CLI11_PARSE(app, argc, argv);
 
     try
@@ -137,6 +213,11 @@ int main(int argc, char** argv)
             if (!dumpAssertedLeds->empty())
             {
                 return dumpAssertedLedObjectPaths();
+            }
+
+            if (!dumpInventoryPathWithLedPath->empty())
+            {
+                return dumpLedPathWithInventoryPath();
             }
         }
     }


### PR DESCRIPTION
This commit adds flag in LED tool to dump LED path with its associated inventory path to the console.

output:
```
root@p10bmc:~# led-tool --help
led-tool - A tool to perform operation(s) over LEDs.
Usage: led-tool [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  -f,--functional BOOLEAN     True/False depending upon the functional status of FRU.
  -t,--toggleFaultLeds Needs: --functional
                              Toggles asserted property for fault LEDs according to the functional status passed. Also updates functional property of the FRUs hosted under PIM accordingly.
  -s,--setGuardedFruLeds      Set LEDs for guarded FRUs.
  -d,--defaultLedsState       Sets power, enclosure fault, SAI and enclosure identify to default state.
  -c,--clearPsuFaultLed       Clears PSU fault LEDs.
  -x,--overrideChassisOnCheck Flag to override chassis on check.
  -o,--object TEXT            Object path of the FRU.
  -q,--syncFaultLed Needs: --object
                              Syncs fault LEDs to functional state of the FRU.
  -D,--dumpLedObjectPaths     Dumps LED object paths on console.
  -i,--dumpInventoryPathWithLedPath Needs: --dumpLedObjectPaths
                              Dumps LED path with its associated inventory path on the console.

root@p10bmc:/tmp# led-tool -i -D
======================================================================================================================================================
LED path                                                               | Inventory Path
======================================================================================================================================================
/xyz/openbmc_project/led/groups/partition_system_attention_indicator   | /xyz/openbmc_project/inventory/system
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/platform_system_attention_indicator    | /xyz/openbmc_project/inventory/system
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/enclosure_identify                     | /xyz/openbmc_project/inventory/system
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/enclosure_fault                        | /xyz/openbmc_project/inventory/system/chassis
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/enclosure_identify                     | /xyz/openbmc_project/inventory/system/chassis
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/planar_fault                           | /xyz/openbmc_project/inventory/system/chassis/motherboard
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/planar_identify                        | /xyz/openbmc_project/inventory/system/chassis/motherboard
------------------------------------------------------------------------------------------------------------------------------------------------------
```