### PR TITLE
led tool: For toggling FRUs LEDs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,7 @@ install_data(
 )
 
 subdir('fault-monitor')
+subdir('tools')
 
 build_tests = get_option('tests')
 if not build_tests.disabled()

--- a/tools/clear-psu-fault-leds.hpp
+++ b/tools/clear-psu-fault-leds.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "utility.hpp"
+
+#include <unistd.h>
+
+/**
+ * @brief API to clear PSU fault LEDs.
+ *
+ * The function, sets operational status of powersupply FRU to true as well as
+ * corresponding asserted property of fault led associated with that FRU to
+ * false.
+ *
+ * Note: The retry mechanishm is to wait for LED service to come up without
+ * which the call to fetch endpoints would fail.
+ * Explicit dependency for LED is not added in service as it will delay the
+ * execution further and clearing of PSU LED should happen asap.
+ *
+ */
+void clearPsuFaultLeds()
+{
+    // sufficiently large number within which the LED service should come up.
+    static constexpr auto MAX_RETRY = 120;
+
+    if (utility::isChassisOn())
+    {
+        std::cout
+            << "Abort clearing PSU fault LED. Chassis is in power on state."
+            << std::endl;
+
+        return;
+    }
+
+    std::vector<std::string> interfaces{
+        "xyz.openbmc_project.Inventory.Item.PowerSupply"};
+
+    utility::MapperResponse subTree = utility::getObjectSubtreeForInterfaces(
+        "/xyz/openbmc_project/inventory", 0, interfaces);
+
+    if (subTree.size() == 0)
+    {
+        std::cerr << "No sub tree found for power supply interfaces. Exiting."
+                  << std::endl;
+
+        return;
+    }
+
+    for (const auto& [objectPath, serviceInterfaceMap] : subTree)
+    {
+        // Find the service which hosts the current objectPath.
+        if (!serviceInterfaceMap.contains(
+                "xyz.openbmc_project.Inventory.Manager"))
+        {
+            // If this object path is not hosted by inventory manager service,
+            // do not take any action.
+            continue;
+        }
+
+        auto retryCounter = MAX_RETRY;
+
+        while (retryCounter != 0)
+        {
+            utility::ListOfObjectPaths objPathList =
+                utility::GetAssociatedSubTreePaths(
+                    std::string(objectPath + "/fault_identifying"),
+                    std::string("/xyz/openbmc_project/led/groups"), 0,
+                    std::vector<std::string>{});
+
+            // If path list is empty, implies LED service is not yet up. We
+            // need to wait for the service.
+            if (objPathList.size() == 0)
+            {
+                retryCounter--;
+                sleep(1);
+                continue;
+            }
+            break;
+        }
+
+        // timer exhausted. Flag the error.
+        if (retryCounter == 0)
+        {
+            std::cerr << "Could not find associated object path for: "
+                      << objectPath << " Exiting." << std::endl;
+            return;
+        }
+
+        utility::notifyPIM(
+            {{objectPath,
+              {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                {{"Functional", true}}}}}});
+
+        auto retVal = utility::getProperty("xyz.openbmc_project.ObjectMapper",
+                                           objectPath + "/fault_identifying",
+                                           "xyz.openbmc_project.Association",
+                                           "endpoints");
+
+        if (auto endpoints = std::get_if<std::vector<std::string>>(&retVal))
+        {
+            for (const auto& path : *endpoints)
+            {
+                // Asserted is inverse of functional status.
+                utility::setProperty<bool>(
+                    "xyz.openbmc_project.LED.GroupManager", path,
+                    "xyz.openbmc_project.Led.Group", "Asserted", false);
+            }
+
+            std::cout << "Setting endpoint for object path: " << objectPath
+                      << " completed in " << (MAX_RETRY - retryCounter)
+                      << " seconds." << std::endl;
+        }
+        else
+        {
+            std::cout << "No endpoints for path: " << objectPath << std::endl;
+        }
+    }
+}

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,0 +1,207 @@
+#include "clear-psu-fault-leds.hpp"
+#include "sync-fault-leds.hpp"
+#include "toggle-fault-leds.hpp"
+
+#include <CLI/CLI.hpp>
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+/**
+ * @brief An API to dump asserted LED paths to console.
+ *
+ * @returns 0 for success, -1 for failure.
+ */
+int dumpAssertedLedObjectPaths()
+{
+    const std::string savedGroupsPath =
+        "/var/lib/phosphor-led-manager/savedGroups";
+    try
+    {
+        if (std::filesystem::exists(savedGroupsPath))
+        {
+            std::ifstream ledsFilePath(savedGroupsPath);
+
+            if (!ledsFilePath)
+            {
+                throw std::runtime_error(
+                    "Unable to open saved groups file. Can't dump LED path(s).");
+            }
+
+            const nlohmann::json parsedLedFile =
+                nlohmann::json::parse(ledsFilePath);
+
+            for (const auto& ledPath : parsedLedFile["value0"])
+            {
+                std::cout << ledPath << std::endl;
+            }
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Saved groups file is not present. Can't dump LED path(s).");
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "Error while trying to dump asserted led paths. Error : "
+                  << ex.what() << std::endl;
+
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief An API to dump LED path with inventory path.
+ *
+ * This API dumps lED path with its associated inventory paths on the console.
+ *
+ * @returns 0 for success, -1 for failure.
+ */
+int dumpLedPathWithInventoryPath()
+{
+    try
+    {
+        std::cout << std::setfill('=') << std::setw(150) << "" << std::endl;
+
+        std::cout << std::left << std::setw(70) << std::setfill(' ')
+                  << "LED path"
+                  << " | " << std::left << std::setw(80) << std::setfill(' ')
+                  << "Inventory Path" << std::endl;
+
+        std::cout << std::setfill('=') << std::setw(150) << "" << std::endl;
+
+        auto objectSubTreeMap = utility::getObjectSubtreeForInterfaces(
+            "/xyz/openbmc_project/inventory/system", 0,
+            {"xyz.openbmc_project.Association.Definitions"});
+
+        for (const auto& objectInterfaceMap : objectSubTreeMap)
+        {
+            const std::string& inventoryPath = objectInterfaceMap.first;
+
+            auto faultLedPath = utility::GetAssociatedSubTreePaths(
+                std::string(inventoryPath + "/fault_identifying"),
+                std::string("/"), 0, {});
+
+            auto identifyLedPath = utility::GetAssociatedSubTreePaths(
+                std::string(inventoryPath + "/identifying"), std::string("/"),
+                0, {});
+
+            for (const auto& ledPath : faultLedPath)
+            {
+                std::cout << std::left << std::setw(70) << std::setfill(' ')
+                          << ledPath << " | " << std::left << std::setw(80)
+                          << std::setfill(' ') << inventoryPath << std::endl;
+
+                std::cout << std::setfill('-') << std::setw(150) << ""
+                          << std::endl;
+            }
+
+            for (const auto& ledPath : identifyLedPath)
+            {
+                std::cout << std::left << std::setw(70) << std::setfill(' ')
+                          << ledPath << " | " << std::left << std::setw(80)
+                          << std::setfill(' ') << inventoryPath << std::endl;
+
+                std::cout << std::setfill('-') << std::setw(150) << ""
+                          << std::endl;
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr
+            << "Error while dumping LED paths with inventory paths to the console. Error : "
+            << e.what() << std::endl;
+
+        return -1;
+    }
+
+    return 0;
+}
+
+int main(int argc, char** argv)
+{
+    CLI::App app{"led-tool - A tool to perform operation(s) over LEDs."};
+
+    bool isFunctional = true;
+    auto functional = app.add_option(
+        "-f, --functional", isFunctional,
+        "True/False depending upon the functional status of FRU.");
+
+    auto toggleFaultLed =
+        app.add_flag(
+               "-t, --toggleFaultLeds",
+               "Toggles asserted property for fault LEDs according to the "
+               "functional status passed. Also updates functional property "
+               "of the FRUs hosted under PIM accordingly.")
+            ->needs(functional);
+
+    auto clearPsuFaultLed = app.add_flag("-c, --clearPsuFaultLed",
+                                         "Clears PSU fault LEDs.");
+
+    std::string objectPath;
+    auto objectPathOption = app.add_option("-o, --object", objectPath,
+                                           "Object path of the FRU.");
+    auto syncFaultLed =
+        app.add_flag("-q, --syncFaultLed",
+                     "Syncs fault LEDs to functional state of the FRU.")
+            ->needs(objectPathOption);
+
+    auto dumpLedObjectPaths = app.add_flag(
+        "-D, --dumpLedObjectPaths", "Dumps LED object paths on console.");
+
+    auto dumpAssertedLeds =
+        app.add_flag("-a, --dumpAssertedLeds",
+                     "Dumps asserted LED object paths to the console.")
+            ->needs(dumpLedObjectPaths);
+
+    auto dumpInventoryPathWithLedPath =
+        app.add_flag(
+               "-i, --dumpInventoryPathWithLedPath",
+               "Dumps LED path with its associated inventory path to the console.")
+            ->needs(dumpLedObjectPaths);
+
+    CLI11_PARSE(app, argc, argv);
+
+    try
+    {
+        if (*toggleFaultLed)
+        {
+            toggleFaultLeds(isFunctional);
+        }
+
+        if (*clearPsuFaultLed)
+        {
+            clearPsuFaultLeds();
+        }
+
+        if (!syncFaultLed->empty())
+        {
+            doSyncFaultLed(objectPath);
+        }
+
+        if (!dumpLedObjectPaths->empty())
+        {
+            if (!dumpAssertedLeds->empty())
+            {
+                return dumpAssertedLedObjectPaths();
+            }
+
+            if (!dumpInventoryPathWithLedPath->empty())
+            {
+                return dumpLedPathWithInventoryPath();
+            }
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cout << "Led tool failed with exception: " << ex.what()
+                  << std::endl;
+    }
+
+    return 0;
+}

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,10 @@
+tool_sources = ['main.cpp']
+
+led_tools_exe = executable(
+    'led-tool',
+    tool_sources,
+    dependencies: [sdbusplus_dep],
+    include_directories: ['.'],
+    install: true,
+    install_dir: get_option('bindir')
+)

--- a/tools/sync-fault-leds.hpp
+++ b/tools/sync-fault-leds.hpp
@@ -1,0 +1,107 @@
+#pragma once
+#include "utility.hpp"
+
+/**
+ * @brief API to set the asserted property of fault LED of a FRU.
+ *
+ * @param[in] i_fruName - Name of the FRU.
+ * @param[in] i_value - Value to be set.
+ *
+ * @return On success returns true, false otherwise.
+ */
+inline bool setFaultLedAssertedProperty(const std::string& i_fruName,
+                                        const bool& i_value) noexcept
+{
+    return utility::setProperty<bool>(
+        "xyz.openbmc_project.LED.GroupManager",
+        "/xyz/openbmc_project/led/groups/" + i_fruName + "_fault",
+        "xyz.openbmc_project.Led.Group", "Asserted", i_value);
+}
+
+/**
+ * @brief API to set the state property of LED for a given FRU.
+ *
+ * @param[in] i_fruName - Name of the FRU.
+ * @param[in] i_value - Value to be set.
+ *
+ * @return On success returns true, false otherwise.
+ */
+inline bool setPhysicalLedStateProperty(const std::string& i_fruName,
+                                        const std::string& i_value) noexcept
+{
+    return utility::setProperty<std::string>(
+        "xyz.openbmc_project.LED.Controller.pca955x_" + i_fruName,
+        "/xyz/openbmc_project/led/physical/pca955x_" + i_fruName,
+        "xyz.openbmc_project.Led.Physical", "State", i_value);
+}
+
+/**
+ * @brief API to sync asserted and state properties of a fault LED of a FRU.
+ *
+ * This API syncs asserted and state properties of a fault LED of a FRU
+ * according to the functional property of the FRU.
+ *
+ * @param[in] i_objectPath - Object path of FRU
+ *
+ * @throw std::runtime_error
+ */
+void doSyncFaultLed(const std::string& i_objectPath)
+{
+    try
+    {
+        constexpr auto MAX_CONFIRMATION_STR_LENGTH{3};
+        std::string l_confirmation{};
+        std::cout
+            << "Don't use this option if the FRU is in identified state. Doing this can create out of sync issue for the LED. Do you really wish to proceed further?[yes/no]:";
+        std::cin >> std::setw(MAX_CONFIRMATION_STR_LENGTH) >> l_confirmation;
+
+        if (l_confirmation != "yes")
+        {
+            return;
+        }
+
+        // extract the FRU name from object path
+        const std::string& l_fruName =
+            sdbusplus::message::object_path(i_objectPath).filename();
+
+        // get the Functional property from PIM
+        const auto l_functionalProperty = utility::getProperty(
+            "xyz.openbmc_project.Inventory.Manager",
+            "/xyz/openbmc_project/inventory" + i_objectPath,
+            "xyz.openbmc_project.State.Decorator.OperationalStatus",
+            "Functional");
+
+        if (const auto l_functionalPropertyVal =
+                std::get_if<bool>(&l_functionalProperty))
+        {
+            const bool& l_functional = *l_functionalPropertyVal;
+
+            // set asserted property of fault LED
+            // asserted property is inverse of functional property
+            if (!setFaultLedAssertedProperty(l_fruName, !l_functional))
+            {
+                throw std::runtime_error("Failed to set asserted property.");
+            }
+
+            // set physical LED state
+            if (!setPhysicalLedStateProperty(
+                    l_fruName,
+                    l_functional
+                        ? "xyz.openbmc_project.Led.Physical.Action.Off"
+                        : "xyz.openbmc_project.Led.Physical.Action.On"))
+            {
+                throw std::runtime_error("Failed to set physical property.");
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Failed to get functional property.");
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        throw std::runtime_error(
+            "Failed to sync fault LED properties for FRU [" + i_objectPath +
+            "]. Error: " + std::string(l_ex.what()));
+    }
+}

--- a/tools/toggle-fault-leds.hpp
+++ b/tools/toggle-fault-leds.hpp
@@ -1,0 +1,117 @@
+#pragma once
+#include "utility.hpp"
+
+/**
+ * @brief API to toggle fault LEDs according to the given functional status.
+ *
+ * The API sets "Functional" property hosted by operational status interface for
+ * all the FRUs under root path "/xyz/openbmc_project/inventory". It also
+ * fetches associated LEDs object path for FRUs, hosted under LED manager and
+ * sets asserted value accordingly.
+ *
+ * The API skips some specific FRUs, although they host operational status based
+ * on following criteria.
+ * - Can be a guarded FRU.
+ * - Operational status of the FRU is handled by some other module.
+ *
+ * @param[in] isFunctional - States if the FRUs are functional or not.
+ */
+void toggleFaultLeds(const bool isFunctional)
+{
+    std::cout << "Trigger toggling of fault LEDs with value: " << isFunctional
+              << std::endl;
+
+    std::vector<std::string> skipOperationalStatusForFRUs{
+        "core", "powersupply", "unit", "connector", "chassis1"};
+
+    std::vector<std::string> frusWithoutLED{
+        "pcie_card", "usb",    "drive",       "ethernet",  "fan0_",
+        "fan1_",     "fan2_",  "fan3_",       "fan4_",     "fan5_",
+        "rdx",       "cables", "displayport", "pcieslot12"};
+
+    if (utility::isChassisOn())
+    {
+        std::cout << "Abort toggling fault LED. Chassis is in power on state."
+                  << std::endl;
+
+        return;
+    }
+
+    std::vector<std::string> interfaces{
+        "xyz.openbmc_project.State.Decorator.OperationalStatus"};
+
+    utility::MapperResponse subTree = utility::getObjectSubtreeForInterfaces(
+        "/xyz/openbmc_project/inventory", 0, interfaces);
+
+    if (subTree.size() == 0)
+    {
+        std::cout
+            << "No sub tree found for OperationalStatus interfaces. Exiting."
+            << std::endl;
+
+        return;
+    }
+
+    for (const auto& [objectPath, serviceInterfaceMap] : subTree)
+    {
+        // only handle paths which are hosted by PIM
+        if (!serviceInterfaceMap.contains(
+                "xyz.openbmc_project.Inventory.Manager"))
+        {
+            // If this object path is not hosted by inventory manager service,
+            // do not take any action.
+            continue;
+        }
+
+        if (std::any_of(skipOperationalStatusForFRUs.cbegin(),
+                        skipOperationalStatusForFRUs.cend(),
+                        [&objectPath](const std::string& aFru) {
+            return objectPath.find(aFru) != std::string::npos;
+        }))
+        {
+            // Skip setting operational status for these paths.
+            continue;
+        }
+
+        utility::notifyPIM(
+            {{objectPath,
+              {{"xyz.openbmc_project.State.Decorator.OperationalStatus",
+                {{"Functional", isFunctional}}}}}});
+
+        if (std::any_of(frusWithoutLED.cbegin(), frusWithoutLED.cend(),
+                        [&objectPath](const std::string& aFru) {
+            // should skip for pcie_cards base path and connectors, not for cxp
+            // ports as they have LEDs
+            if (objectPath.find("cxp_top") != std::string::npos ||
+                objectPath.find("cxp_bot") != std::string::npos)
+            {
+                return false;
+            }
+            return objectPath.find(aFru) != std::string::npos;
+        }))
+        {
+            // Skipping path with no LEDs.
+            continue;
+        }
+
+        auto retVal = utility::getProperty("xyz.openbmc_project.ObjectMapper",
+                                           objectPath + "/fault_identifying",
+                                           "xyz.openbmc_project.Association",
+                                           "endpoints");
+
+        if (auto endpoints = std::get_if<std::vector<std::string>>(&retVal))
+        {
+            for (const auto& path : *endpoints)
+            {
+                // Asserted is inverse of functional status.
+                utility::setProperty<bool>(
+                    "xyz.openbmc_project.LED.GroupManager", path,
+                    "xyz.openbmc_project.Led.Group", "Asserted", !isFunctional);
+            }
+        }
+        else
+        {
+            std::cout << "No endpoints for path: " << objectPath << std::endl;
+        }
+    }
+}

--- a/tools/utility.hpp
+++ b/tools/utility.hpp
@@ -1,0 +1,268 @@
+#pragma once
+#include <sdbusplus/server.hpp>
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace utility
+{
+
+// This covers mostly all the data type supported over Dbus for a property.
+// clang-format off
+using DbusVariantType = std::variant<
+    std::monostate,
+    std::vector<std::tuple<std::string, std::string, std::string>>,
+    std::vector<std::string>,
+    std::vector<double>,
+    std::string,
+    int64_t,
+    uint64_t,
+    double,
+    int32_t,
+    uint32_t,
+    int16_t,
+    uint16_t,
+    uint8_t,
+    bool,
+    std::vector<uint32_t>,
+    std::vector<uint16_t>,
+    sdbusplus::message::object_path,
+    std::tuple<uint64_t, std::vector<std::tuple<std::string, std::string, double, uint64_t>>>,
+    std::vector<std::tuple<std::string, std::string>>,
+    std::vector<std::tuple<uint32_t, std::vector<uint32_t>>>,
+    std::vector<std::tuple<uint32_t, size_t>>,
+    std::vector<std::tuple<sdbusplus::message::object_path, std::string,
+                           std::string, std::string>>
+>;
+
+/**
+ * @brief An API to make GetSubTree mapper call.
+ *
+ * @return MapperResponse - Response from the API.
+ */
+// map<inventory_path, map<service_name, vector<interface>>>
+using MapperResponse =
+    std::map<std::string, std::map<std::string, std::vector<std::string>>>;
+
+MapperResponse
+    getObjectSubtreeForInterfaces(const std::string& root, const int32_t depth,
+                                  const std::vector<std::string>& interfaces)
+{
+    auto bus = sdbusplus::bus::new_default();
+    auto mapperCall = bus.new_method_call("xyz.openbmc_project.ObjectMapper",
+                                          "/xyz/openbmc_project/object_mapper",
+                                          "xyz.openbmc_project.ObjectMapper",
+                                          "GetSubTree");
+    mapperCall.append(root);
+    mapperCall.append(depth);
+    mapperCall.append(interfaces);
+
+    MapperResponse result = {};
+
+    try
+    {
+        auto response = bus.call(mapperCall);
+
+        response.read(result);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::cout << "GetSubtree mapper call failed with exception: "
+                  << e.what() << std::endl;
+    }
+    return result;
+}
+
+/**
+ * @brief An API to get associated object paths.
+ *
+ * @param[in] associationPath - The path to look for the association endpoints.
+ * @param[in] root - The root of the tree to look into.
+ * @param[in] depth - The maximum depth of the tree past the root to search.
+ * @param[in] interfaces - Optional list of interfaces to constrain the search.
+ * @return ListOfObjectPaths - List of object paths associted.
+ */
+using ListOfObjectPaths = std::vector<std::string>;
+ListOfObjectPaths GetAssociatedSubTreePaths(
+    const sdbusplus::message::object_path& associationPath,
+    const sdbusplus::message::object_path& root, const int32_t depth,
+    const std::vector<std::string>& interfaces)
+{
+    auto bus = sdbusplus::bus::new_default();
+    auto mapperCall = bus.new_method_call("xyz.openbmc_project.ObjectMapper",
+                                          "/xyz/openbmc_project/object_mapper",
+                                          "xyz.openbmc_project.ObjectMapper",
+                                          "GetAssociatedSubTreePaths");
+    mapperCall.append(associationPath);
+    mapperCall.append(root);
+    mapperCall.append(depth);
+    mapperCall.append(interfaces);
+
+    ListOfObjectPaths result = {};
+
+    try
+    {
+        auto response = bus.call(mapperCall);
+
+        response.read(result);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::cerr
+            << "GetAssociatedSubTreePaths mapper call failed with exception: "
+            << e.what() << std::endl;
+    }
+    return result;
+}
+
+/**
+ * @brief Templated API to set D-Bus property.
+ *
+ * @param[in] serviceName - D-Bus service name hosting the object path.
+ * @param[in] objectPath - D-Bus object path hosting the interface.
+ * @param[in] interface - D-Bus interface hosting the property.
+ * @param[in] property - D-Bus property to be set.
+ * @param[in] value - Value to be set.
+ *
+ * @return On success, returns true, false otherwise.
+ */
+template <typename T>
+bool setProperty(const std::string& serviceName, const std::string& objectPath,
+                 const std::string& interface, const std::string& property,
+                 const std::variant<T>& value) noexcept
+{
+    bool l_rc{true};
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method =
+            bus.new_method_call(serviceName.c_str(), objectPath.c_str(),
+                                "org.freedesktop.DBus.Properties", "Set");
+
+        method.append(interface);
+        method.append(property);
+        method.append(value);
+        bus.call(method);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cerr << "Set property: " << property
+                  << " failed for path: " << objectPath
+                  << " with error: " << e.what() << std::endl;
+        l_rc = false;
+    }
+    return l_rc;
+}
+
+/**
+ * @brief Templated API to get D-Bus property.
+ *
+ * @param[in] serviceName - D-Bus service name hosting the object path.
+ * @param[in] objectPath - D-Bus object path hosting the interface.
+ * @param[in] interface - D-Bus interface hosting the property.
+ * @param[in] property - D-Bus property whose value is to be fetched.
+ * @return Value of the property.
+ */
+DbusVariantType getProperty(const std::string& serviceName, const std::string& objectPath,
+              const std::string& interface, const std::string& property)
+{
+    DbusVariantType result;
+
+    if(serviceName.empty() || objectPath.empty() || interface.empty() || property.empty())
+    {
+        std::cout << "One of the parameters required to make Dbus get call is empty" << std::endl;
+        return result;
+    }
+
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto mapperCall =
+        bus.new_method_call(serviceName.c_str(), objectPath.c_str(),
+                            "org.freedesktop.DBus.Properties", "Get");
+    mapperCall.append(interface);
+    mapperCall.append(property);
+        auto response = bus.call(mapperCall);
+
+        response.read(result);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        std::cerr << "Get property: " << property
+                  << " failed for path: " << objectPath
+                  << " with error: " << e.what() << std::endl;
+    }
+
+    return result;
+}
+
+/**
+ * @brief An API to check chassis power state.
+ *
+ * @return bool - True when chassis power state is on, false otherwise.
+ */
+bool isChassisOn()
+{
+    auto retVal = getProperty(
+        "xyz.openbmc_project.State.Chassis0",
+        "/xyz/openbmc_project/state/chassis0",
+        "xyz.openbmc_project.State.Chassis", "CurrentPowerState");
+
+    if (auto powerSate = std::get_if<std::string>(&retVal))
+    {
+        if (*powerSate == "xyz.openbmc_project.State.Chassis.PowerState.On")
+        {
+            return true;
+        }
+    }
+
+    // In any error condition assuming chassis is off.
+    return false;
+}
+
+using ObjectMap =
+    std::map<sdbusplus::message::object_path,
+             std::map<std::string, std::map<std::string, std::variant<bool>>>>;
+
+/**
+ * @brief An API to call PIM
+ *
+ * This API calls notify method of PIM to update the property value.
+ *
+ * @param[in] objectMap - Map of object path, interface, property and its value.
+ */
+void notifyPIM(ObjectMap&& objectMap)
+{
+    try
+    {
+        for (const auto& objectKeyValue : objectMap)
+        {
+            auto objectPath = objectMap.extract(objectKeyValue.first);
+
+            if (objectPath.key().str.find("/xyz/openbmc_project/inventory",
+                                          0) != std::string::npos)
+            {
+                objectPath.key() = objectPath.key().str.replace(
+                    0, strlen("/xyz/openbmc_project/inventory"), "");
+                objectMap.insert(std::move(objectPath));
+            }
+        }
+
+        auto bus = sdbusplus::bus::new_default();
+        auto pimMsg = bus.new_method_call(
+            "xyz.openbmc_project.Inventory.Manager",
+            "/xyz/openbmc_project/inventory",
+            "xyz.openbmc_project.Inventory.Manager", "Notify");
+        pimMsg.append(std::move(objectMap));
+        bus.call(pimMsg);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cerr << "Notify PIM to update property value failed with error: "
+                  << e.what() << std::endl;
+    }
+}
+} // namespace utility


### PR DESCRIPTION
The commit implements led-tool, the application provides various LEDs
toggling functionalities, which will be used for setting LEDs in different
scenarios.

led-tool provides the following options,
* Toggles asserted property for fault LEDs according to the functional
status passed. Also updates functional property of the FRUs hosted
under PIM accordingly.
* Sync asserted property of the fault LED of an FRU according to the
functional property of the FRU.
* Clear fault LEDs for PSU.
* Dump asserted LEDs object paths on the console.
* Dumps LED path with its associated inventory path on the console.

```
Output:
root@p10bmc:/tmp# ./led-tool  -h
led-tool - A tool to perform operation(s) over LEDs.
Usage: ./led-tool [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  -f,--functional BOOLEAN     True/False depending upon the functional status of FRU.
  -t,--toggleFaultLeds Needs: --functional
                              Toggles asserted property for fault LEDs according to the functional status passed. Also updates functional property of the FRUs hosted under PIM accordingly.
  -c,--clearPsuFaultLed       Clears PSU fault LEDs.
  -o,--object TEXT            Object path of the FRU.
  -q,--syncFaultLed Needs: --object
                              Syncs fault LEDs to functional state of the FRU.
  -D,--dumpLedObjectPaths     Dumps LED object paths on console.
  -a,--dumpAssertedLeds Needs: --dumpLedObjectPaths
                              Dumps asserted LED object paths to the console.
  -i,--dumpInventoryPathWithLedPath Needs: --dumpLedObjectPaths
                              Dumps LED path with its associated inventory path to the console.

Test cases::

Get asserted LEDs:
root@p10bmc:~# led-tool -a -D
"/xyz/openbmc_project/led/groups/bmc_booted"
"/xyz/openbmc_project/led/groups/powersupply0_fault"

Clear PSU fault LEDs:
1. Before:
root@p10bmc:~# led-tool -a -D
"/xyz/openbmc_project/led/groups/bmc_booted"
"/xyz/openbmc_project/led/groups/powersupply0_fault"

2. Apply clear PSU falue LED command:
root@p10bmc:~# led-tool -c
Setting endpoint for object path: /xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0 completed in 0 seconds.
Setting endpoint for object path: /xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1 completed in 0 seconds.

3. After clearing :
root@p10bmc:~# led-tool -a -D
"/xyz/openbmc_project/led/groups/bmc_booted"

Sync LED with its functional state:
1. Set functional state of an FRU as ‘false’ using Dbus command.
busctl  set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 xyz.openbmc_project.State.Decorator.OperationalStatus Functional b false

2. Set asserted state of the FRU as ‘false’.
busctl set-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/cpu0_fault xyz.openbmc_project.Led.Group Asserted b false

3. Now FRU functional state is ‘false, but LED asserted property is ‘false’.
root@p10bmc:~# busctl  get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0 xyz.openbmc_project.State.Decorator.OperationalStatus Functional
b false

root@p10bmc:~# busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/cpu0_fault xyz.openbmc_project.Led.Group Asserted
b false

4. led-tool to sync asserted property of an FRU with its functional state.
root@p10bmc:~# led-tool  -q -o /system/chassis/motherboard/dcm0/cpu0
Don't use this option if the FRU is in identified state. Doing this can create out of sync issue for the LED. Do you really wish to proceed further?[yes/no]:yes

5. After sync.
root@p10bmc:~# busctl get-property xyz.openbmc_project.LED.GroupManager /xyz/openbmc_project/led/groups/cpu0_fault xyz.openbmc_project.Led.Group Asserted
b true

Toggle Fault LEDs:
1. Fault LEDs list:
root@p10bmc:~# led-tool -D -a
"/xyz/openbmc_project/led/groups/bmc_booted"
"/xyz/openbmc_project/led/groups/cpu0_fault"

2. Apply fault toggle
root@p10bmc:~# led-tool -t -f true
Trigger toggling of fault LEDs with value: 1

3. After toggling:
root@p10bmc:~# led-tool -D -a
"/xyz/openbmc_project/led/groups/bmc_booted"

Dumps LED path with its associated inventory:
root@p10bmc:/tmp# ./led-tool  -D -i
======================================================================================================================================================
LED path                                                               | Inventory Path
======================================================================================================================================================
/xyz/openbmc_project/led/groups/enclosure_fault                        | /xyz/openbmc_project/inventory/system/chassis
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/enclosure_identify                     | /xyz/openbmc_project/inventory/system/chassis
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/planar_fault                           | /xyz/openbmc_project/inventory/system/chassis/motherboard
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/planar_identify                        | /xyz/openbmc_project/inventory/system/chassis/motherboard
------------------------------------------------------------------------------------------------------------------------------------------------------
Note: only kept few lines of the output for the above command, as it contains huge no of entries.
```

Signed-off-by: Anupama B R <anupama.b.r1@ibm.com>
