### PR TITLE
LEDTool: Dump the LED Group Objects

### DIFF
--- a/tools/dump-led-object-paths.hpp
+++ b/tools/dump-led-object-paths.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include "utility.hpp"
+
+/**
+ * @brief API to dump all the led object paths.
+ */
+void dumpLEDObjectPaths()
+{
+    std::vector<std::string> interfaces;
+
+    const utility::MapperResponse subTree =
+        utility::getObjectSubtreeForInterfaces(
+            "/xyz/openbmc_project/led/groups", 0, interfaces);
+
+    if (subTree.empty())
+    {
+        std::cout << "No sub tree found for led groups. Exiting." << std::endl;
+        return;
+    }
+
+    std::cout << "xyz.openbmc_project.LED.GroupManager" << "\n";
+    for (const auto& [objectPath, serviceInterfaceMap] : subTree)
+    {
+        if (serviceInterfaceMap.find("xyz.openbmc_project.LED.GroupManager") !=
+            serviceInterfaceMap.end())
+        {
+            std::cout << "    " << objectPath << "\n";
+        }
+    }
+}

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,4 +1,5 @@
 #include "clear-psu-fault-leds.hpp"
+#include "dump-led-object-paths.hpp"
 #include "set-guarded-fru-leds.hpp"
 #include "set-leds-default-state.hpp"
 #include "sync-fault-leds.hpp"
@@ -219,6 +220,8 @@ int main(int argc, char** argv)
             {
                 return dumpLedPathWithInventoryPath();
             }
+
+            dumpLEDObjectPaths();
         }
     }
     catch (const std::exception& ex)


### PR DESCRIPTION
Test-
Tested the led-tool patch on system. Works fine.
root@p10bmc:/tmp/test# ./led-tool -D
Dump the objects under LED Group
xyz.openbmc_project.LED.GroupManager
    /xyz/openbmc_project/led/groups/base_blyth_fault
    /xyz/openbmc_project/led/groups/base_blyth_identify
    /xyz/openbmc_project/led/groups/bmc_booted
    /xyz/openbmc_project/led/groups/bmc_ingraham_fault
    ....