### PR TITLE
led-tool: restrict usage access

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -3,10 +3,12 @@
 #include "set-leds-default-state.hpp"
 #include "sync-fault-leds.hpp"
 #include "toggle-fault-leds.hpp"
+#include "utility.hpp"
 
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -128,6 +130,9 @@ int dumpLedPathWithInventoryPath()
 
 int main(int argc, char** argv)
 {
+    const bool fieldmodeEnabled = utility::isFieldModeEnabled();
+    const bool isSystemdService = utility::runningAsSystemDService();
+
     CLI::App app{"led-tool - A tool to perform operation(s) over LEDs."};
 
     bool isFunctional = true;
@@ -182,6 +187,15 @@ int main(int argc, char** argv)
 
     try
     {
+        if (!isSystemdService && !fieldmodeEnabled &&
+            (!toggleFaultLed->empty() || !setGuardedFruLeds->empty() ||
+             !defaultLedsSate->empty() || !clearPsuFaultLed->empty() ||
+             !syncFaultLed->empty()))
+        {
+            std::cerr << "This option enabled only in field mode." << std::endl;
+            return -1;
+        }
+
         if (*toggleFaultLed)
         {
             toggleFaultLeds(isFunctional,

--- a/tools/utility.hpp
+++ b/tools/utility.hpp
@@ -265,4 +265,61 @@ void notifyPIM(ObjectMap&& objectMap)
                   << e.what() << std::endl;
     }
 }
+
+/**
+ * @brief API to check if field mode enabled.
+ *
+ * @return true, if field mode is enabled. otherwise false.
+ */
+bool isFieldModeEnabled() noexcept
+{
+    try
+    {
+        std::vector<std::string> l_cmdOutput;
+        std::array<char, 256> l_buffer;
+
+        const std::string l_cmd = "/sbin/fw_printenv fieldmode";
+
+        std::unique_ptr<FILE, int (*)(FILE*)> l_cmdPipe(
+            popen(l_cmd.c_str(), "r"), pclose);
+
+        if (!l_cmdPipe)
+        {
+            throw std::runtime_error("popen failed, error:" +
+                                     std::string(strerror(errno)));
+        }
+
+        // Read the command output
+        while (fgets(l_buffer.data(), l_buffer.size(), l_cmdPipe.get()) !=
+               nullptr)
+        {
+            l_cmdOutput.emplace_back(l_buffer.data());
+        }
+
+        // Convert the read command output into lowercase
+        if (l_cmdOutput.size() > 0)
+        {
+            std::transform(l_cmdOutput[0].begin(), l_cmdOutput[0].end(),
+                           l_cmdOutput[0].begin(), [](unsigned char l_char) {
+                return std::tolower(l_char);
+            });
+
+            // Remove the new line character from the string.
+            l_cmdOutput[0].erase(l_cmdOutput[0].length() - 1);
+
+            return l_cmdOutput[0] == "fieldmode=true" ? true : false;
+        }
+    }
+    catch (const std::exception& l_ex)
+    {
+        std::cout << "Error while reading fieldmode: " << l_ex.what() << std::endl;
+    }
+
+    return false;
+}
+
+bool runningAsSystemDService() noexcept
+{
+    return std::getenv("SYSTEMD_EXEC_PID") != nullptr ? true : false;
+}
 } // namespace utility


### PR DESCRIPTION
This commits adds restriction on led-tool usage, led-tool all options
are enabled only in field mode or can be run as a part of systemd
service files irrespective field mode enabled or not. In absence of
field mode only dumpAssertedLeds and dumpInventoryPathWithLedPath
options are enabled.

```
Ouput:

led-tool running as a part of systemd service, when fieldmode is not set:
Jul 28 06:17:59 p11bmc obmc-clear-all-fault-leds-and-remove-crit-association[1714]: ## Error: "fieldmode" not defined
Jul 28 06:17:59 p11bmc obmc-clear-all-fault-leds-and-remove-crit-association[1711]: system_exec_pid: 1711
Jul 28 06:17:59 p11bmc obmc-clear-all-fault-leds-and-remove-crit-association[1711]: Trigger toggling of fault LEDs with value: 1

led-tool running as a part of systemd service, when fieldmode is enabled:
Jul 29 08:46:32 p11bmc obmc-clear-all-fault-leds-and-remove-crit-association[2744]: system_exec_pid: 2744
Jul 29 08:46:32 p11bmc obmc-clear-all-fault-leds-and-remove-crit-association[2744]: Trigger toggling of fault LEDs with value: 1

Some of the LED tool options are not enabled when fieldmode is not enabled:
root@p11bmc:~# led-tool -d
This option enabled only in field mode.
root@p11bmc:~# led-tool -c
This option enabled only in field mode.
root@p11bmc:~# led-tool -s
This option enabled only in field mode.

Dumps asserted LED object paths command is enabled even when fieldmode is not set:
root@p11bmc:~# led-tool -D -a
"/xyz/openbmc_project/led/groups/bmc_booted"
"/xyz/openbmc_project/led/groups/platform_system_attention_indicator"
"/xyz/openbmc_project/led/groups/power_on"

Dumps LED path with its associated inventory path when fieldmode is not set:
root@p11bmc:~# led-tool -D -i
======================================================================================================================================================
LED path                                                               | Inventory Path
======================================================================================================================================================
/xyz/openbmc_project/led/groups/enclosure_fault                        | /xyz/openbmc_project/inventory/system/chassis
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/enclosure_identify                     | /xyz/openbmc_project/inventory/system/chassis
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/planar_fault                           | /xyz/openbmc_project/inventory/system/chassis/motherboard
------------------------------------------------------------------------------------------------------------------------------------------------------
/xyz/openbmc_project/led/groups/planar_identify                        | /xyz/openbmc_project/inventory/system/chassis/motherboard
------------------------------------------------------------------------------------------------------------------------------------------------------
Note: Kept only part of the log for above command.

led-tool all options enabled in fieldmode:
root@p11bmc:~# led-tool -d
Trigger set default state for LEDs.
Abort setting LEDs to default as chassis is in power on state.
```

Signed-off-by: Anupama B R <anupama.b.r1@ibm.com>