### PR TITLE
led-tool: fix multiple commands execution

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -227,18 +227,15 @@ int main(int argc, char** argv)
         {
             toggleFaultLeds(isFunctional);
         }
-
-        if (*clearPsuFaultLed)
+        else if (*clearPsuFaultLed)
         {
             clearPsuFaultLeds();
         }
-
-        if (!syncFaultLed->empty())
+        else if (!syncFaultLed->empty())
         {
             doSyncFaultLed(objectPath);
         }
-
-        if (!dumpLedObjectPaths->empty())
+        else if (!dumpLedObjectPaths->empty())
         {
             if (!dumpAssertedLeds->empty())
             {


### PR DESCRIPTION
This commit adds the code to avoid executing multiple commands, in case if user provides multiple options while using led-tool.