### PR TITLE
Support for CXP port in balcones LED config

### DIFF
--- a/configs/com.ibm.Hardware.Chassis.Model.Balcones.json
+++ b/configs/com.ibm.Hardware.Chassis.Model.Balcones.json
@@ -823,6 +823,138 @@
          ]
       },
       {
+         "group" : "cablecard2_cxp_top_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_cablecard2_cxp_top",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "cablecard2_cxp_top_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_cablecard2_cxp_top",
+               "Action" : "Blink",
+               "DutyOn" : 50,
+               "Period" : 1000,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "cablecard2_cxp_bot_fault",
+         "members" : [
+            {
+               "Name" : "pca955x_cablecard2_cxp_bot",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "pca955x_front_enc_fault1",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_fault0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_fault",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
+         "group" : "cablecard2_cxp_bot_identify",
+         "members" : [
+            {
+               "Name" : "pca955x_cablecard2_cxp_bot",
+               "Action" : "Blink",
+               "DutyOn" : 50,
+               "Period" : 1000,
+               "Priority" : "Blink"
+            },
+            {
+               "Name" : "pca955x_front_sys_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "led_rear_enc_id0",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            },
+            {
+               "Name" : "virtual_enc_id",
+               "Action" : "On",
+               "DutyOn" : 50,
+               "Period" : 0,
+               "Priority" : "On"
+            }
+         ]
+      },
+      {
          "group" : "usb0_identify",
          "members" : [
             {


### PR DESCRIPTION
This commit adds entry of CXP port identify and fault in Balcones LED config JSON.